### PR TITLE
ci: grant labels permission to Add Release Label workflow

### DIFF
--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -81,6 +81,14 @@ jobs:
     runs-on: ubuntu-latest
     name: Add Release Label
     if: startsWith(github.head_ref, 'release/v')
+    # Narrowest grant that unblocks the labels call. The default
+    # GITHUB_TOKEN in this repo is read-only, so the labels API returns
+    # 403 without it. Job-scoped (no other job inherits this), no
+    # checkout, no PR-supplied code is executed; the only call is a
+    # hard-coded `addLabels` with the fixed label 'release'. Fork PRs
+    # are auto-downgraded to read by GitHub regardless of this grant.
+    permissions:
+      pull-requests: write
     steps:
       - name: Add release label
         uses: actions/github-script@v9


### PR DESCRIPTION
The `add_release_label` job in `release_test.yml` calls
`github.rest.issues.addLabels` via `actions/github-script`, but this
repository's default `GITHUB_TOKEN` is read-only, so the call returns:

```
Resource not accessible by integration (403)
```

Observed on PR #66 (Release v1.8.1) - the rest of the validation suite
passes, but this single job fails on every release PR.

Adds the narrowest grant that unblocks it: `pull-requests: write`,
scoped only to this one job. This matches what `actions/labeler`
recommends for PR-labelling workflows.

### Safety

- Grant is **job-scoped**; no other job or workflow inherits it.
- Job does **not** `checkout`, `pip install`, or run any PR-supplied
  code. Its only step is one hard-coded `addLabels` call with a fixed
  label `'release'`.
- Fork PRs are auto-downgraded to read-only by GitHub regardless of
  what the workflow requests on `pull_request` events.
- `if: startsWith(github.head_ref, 'release/v')` already constrains
  the job to release branches in this repo.

### Verification limit

The job is gated by `if: startsWith(github.head_ref, 'release/v')` so
it does not run on this `fix/...` PR. The fix can only be confirmed on
the next release PR (e.g. v1.8.2).