### PR TITLE
Fix exchange-rate retrieval failures and ECB-outage resilience (#68)

### DIFF
--- a/custom_components/ge_spot/__init__.py
+++ b/custom_components/ge_spot/__init__.py
@@ -29,9 +29,21 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 async def async_setup(hass: HomeAssistant, config):  # pylint: disable=unused-argument
     """Set up the GE-Spot component."""
-    # Initialize exchange rate service and register update handlers
-    exchange_service = await get_exchange_service()
-    exchange_service.register_update_handlers(hass)
+    # Initialize exchange rate service and register update handlers.
+    # A failure here (e.g. ECB briefly unreachable with no fresh cache) must NOT
+    # block the integration from loading: the service degrades gracefully (fresh
+    # fetch -> persistent cache, capped at 24h) and the scheduled handlers keep
+    # retrying, so we log and continue rather than fail setup.
+    try:
+        exchange_service = await get_exchange_service(hass=hass)
+        exchange_service.register_update_handlers(hass)
+    except Exception as e:  # pragma: no cover - defensive, get_rates already soft-fails
+        _LOGGER.warning(
+            "Exchange rate service could not be initialized at setup: %s. "
+            "Currency conversion will use cached/fallback rates where available "
+            "and retry automatically.",
+            e,
+        )
 
     return True
 

--- a/custom_components/ge_spot/const/api.py
+++ b/custom_components/ge_spot/const/api.py
@@ -80,6 +80,13 @@ class ECB:
     XML_NAMESPACE_GESMES = "http://www.gesmes.org/xml/2002-08-01"
     XML_NAMESPACE_ECB = "http://www.ecb.int/vocabulary/2002-08-01/eurofxref"
 
+    # Maximum age for non-live exchange rates loaded from the persistent cache.
+    # ECB publishes new reference rates once per TARGET working day, so rates
+    # older than this risk being materially wrong and must never be used for
+    # price conversion. When no rate this fresh is available, conversion is
+    # skipped rather than risk wrong prices. 24h = 24 * 60 * 60 = 86400 seconds.
+    RATES_MAX_AGE_SECONDS = 24 * 60 * 60
+
 
 class ComEd:
     """ComEd API constants."""

--- a/custom_components/ge_spot/coordinator/unified_price_manager.py
+++ b/custom_components/ge_spot/coordinator/unified_price_manager.py
@@ -333,7 +333,7 @@ class UnifiedPriceManager:
         if self._exchange_service is None:
             # Use the singleton helper to get/create the service
             self._exchange_service = await get_exchange_service(
-                session=async_get_clientsession(self.hass)
+                session=async_get_clientsession(self.hass), hass=self.hass
             )
             # Pass the initialized service to the data processor if it expects it
             # Assuming DataProcessor needs the actual service instance:

--- a/custom_components/ge_spot/utils/exchange_service.py
+++ b/custom_components/ge_spot/utils/exchange_service.py
@@ -9,6 +9,7 @@ import json
 import os
 import time
 from homeassistant.helpers.event import async_track_time_change
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from ..const.currencies import Currency
 from ..const.network import Network
@@ -18,6 +19,15 @@ from ..api.base.error_handler import retry_with_backoff
 
 _LOGGER = logging.getLogger(__name__)
 
+# Cache file name used when a Home Assistant config path is available. Stored in
+# the config directory so it survives container/add-on recreation (e.g. version
+# upgrades), unlike the home-directory fallback in _get_default_cache_path.
+EXCHANGE_RATE_CACHE_FILENAME = "ge_spot_exchange_rates.json"
+
+
+class ExchangeRateFetchError(Exception):
+    """Raised when fresh exchange rates cannot be fetched/parsed from ECB."""
+
 
 class ExchangeRateService:
     """Service to fetch and cache currency exchange rates."""
@@ -25,6 +35,10 @@ class ExchangeRateService:
     def __init__(self, session=None, cache_file=None):
         """Initialize the exchange rate service."""
         self.session = session
+        # A session injected by Home Assistant (async_get_clientsession) is
+        # shared and managed by HA; we must never close it. Only a session we
+        # create ourselves (standalone scripts/tests) is owned and closed by us.
+        self._owns_session = session is None
         self.cache_file = cache_file or self._get_default_cache_path()
         self.rates = {}
         self.last_update = 0
@@ -43,36 +57,54 @@ class ExchangeRateService:
             return "/tmp/ge_spot_exchange_rates.json"
 
     async def _ensure_session(self):
-        """Ensure we have an aiohttp session."""
+        """Ensure we have an aiohttp session.
+
+        Fallback only for standalone use (scripts/tests) where no Home Assistant
+        session was injected. In Home Assistant the shared session from
+        async_get_clientsession is passed in via get_exchange_service, which
+        also avoids blocking SSL certificate loading on the event loop.
+        """
         if self.session is None:
             self.session = aiohttp.ClientSession()
+            self._owns_session = True
 
     async def close(self):
-        """Close the session."""
-        if self.session:
+        """Close the session only if we own it.
+
+        A shared Home Assistant session (async_get_clientsession) is managed by
+        HA and must not be closed here.
+        """
+        if self.session and self._owns_session:
             await self.session.close()
             self.session = None
 
     @retry_with_backoff(max_retries=Network.Defaults.RETRY_COUNT)
     async def _fetch_ecb_rates(self):
-        """Fetch exchange rates from European Central Bank API."""
+        """Fetch exchange rates from the European Central Bank.
+
+        Raises on failure (connection error, non-200 status, or unparseable
+        response) instead of returning ``None``. Swallowing the error here would
+        defeat the @retry_with_backoff decorator (it only retries on raised
+        exceptions, so a returned ``None`` looks like success) and hide the real
+        cause from get_rates, so the error is allowed to propagate.
+        """
         await self._ensure_session()
 
-        try:
-            async with self.session.get(
-                Network.URLs.ECB, timeout=Network.Defaults.HTTP_TIMEOUT
-            ) as response:
-                if response.status != 200:
-                    _LOGGER.error(
-                        "Failed to fetch exchange rates: HTTP %s", response.status
-                    )
-                    return None
+        async with self.session.get(
+            Network.URLs.ECB, timeout=Network.Defaults.HTTP_TIMEOUT
+        ) as response:
+            if response.status != 200:
+                raise ExchangeRateFetchError(
+                    f"Failed to fetch exchange rates: HTTP {response.status}"
+                )
+            xml_data = await response.text()
 
-                xml_data = await response.text()
-                return self._parse_ecb_xml(xml_data)
-        except Exception as e:
-            _LOGGER.error("Error fetching exchange rates: %s", e)
-            return None
+        rates = self._parse_ecb_xml(xml_data)
+        if not rates:
+            raise ExchangeRateFetchError(
+                "ECB response could not be parsed into exchange rates"
+            )
+        return rates
 
     def _parse_ecb_xml(self, xml_data):
         """Parse ECB exchange rate XML data."""
@@ -99,38 +131,54 @@ class ExchangeRateService:
             return None
 
     async def _load_cache(self):
-        """Load exchange rates from cache file asynchronously."""
-        if not os.path.exists(self.cache_file):
-            return False
+        """Load exchange rates from the cache file if present and within max age.
 
+        Uses async file I/O only (aiofiles, which reads on a worker thread) so no
+        blocking disk I/O runs on the event loop -- os.path.exists/getmtime would
+        each call the blocking os.stat. Cached rates older than
+        ECB.RATES_MAX_AGE_SECONDS are ignored (treated as a cache miss) so stale
+        rates can never be used for conversion.
+        """
         try:
-            modified_time = os.path.getmtime(self.cache_file)
-
             async with aiofiles.open(self.cache_file, "r") as f:
                 content = await f.read()
-                data = json.loads(content)
-
-            if not data or "rates" not in data:
-                return False
-
-            self.rates = data["rates"]
-
-            # Ensure cents currency is always available
-            if Currency.CENTS not in self.rates:
-                self.rates[Currency.CENTS] = 100.0
-
-            self.last_update = data.get("timestamp", modified_time)
-
-            age = time.time() - self.last_update
-            _LOGGER.info(
-                "Loaded exchange rates from cache (age: %.1fs, currencies: %d)",
-                age,
-                len(self.rates),
-            )
-            return True
+            data = json.loads(content)
+        except FileNotFoundError:
+            return False
         except Exception as e:
             _LOGGER.error("Error loading exchange rate cache: %s", e)
             return False
+
+        if not data or "rates" not in data:
+            return False
+
+        # _save_cache always writes "timestamp"; default to 0 (treated as stale)
+        # if a legacy/hand-written file lacks it.
+        timestamp = data.get("timestamp", 0)
+        age = time.time() - timestamp
+        if age > ECB.RATES_MAX_AGE_SECONDS:
+            _LOGGER.info(
+                "Ignoring cached exchange rates: older than max age "
+                "(age: %.1fh, max: %.1fh)",
+                age / 3600,
+                ECB.RATES_MAX_AGE_SECONDS / 3600,
+            )
+            return False
+
+        self.rates = data["rates"]
+
+        # Ensure cents currency is always available
+        if Currency.CENTS not in self.rates:
+            self.rates[Currency.CENTS] = 100.0
+
+        self.last_update = timestamp
+
+        _LOGGER.info(
+            "Loaded exchange rates from cache (age: %.1fs, currencies: %d)",
+            age,
+            len(self.rates),
+        )
+        return True
 
     async def _save_cache(self):
         """Save exchange rates to cache file asynchronously."""
@@ -154,25 +202,38 @@ class ExchangeRateService:
             return False
 
     async def get_rates(self, force_refresh=False):
-        """Get exchange rates (from cache or fresh fetch)."""
+        """Get exchange rates, always preferring fresh ECB data.
+
+        Rates are only ever returned when no older than ECB.RATES_MAX_AGE_SECONDS
+        (stale rates risk materially wrong prices). Resolution order:
+        fresh ECB fetch -> persistent cache within max age. The cache is written
+        on every successful fetch, so it acts as a self-updating fallback. If
+        nothing qualifies, an empty dict is returned and callers skip conversion
+        gracefully. This method never raises, so a transient ECB outage can never
+        block setup or price processing.
+        """
         now = time.time()
-        cache_loaded = False
-        if not self.rates:  # If no rates in memory
-            cache_loaded = await self._load_cache()
 
-        # Decide if fetch is needed
-        needs_fetch = (
-            force_refresh or not self.rates
-        )  # Fetch if forced or no rates in memory/cache
+        # Discard in-memory rates that have aged out so they can't be reused.
+        if self.rates and not self._rates_fresh():
+            _LOGGER.info("Held exchange rates exceeded max age; discarding.")
+            self.rates = {}
+            self.last_update = 0
 
-        if needs_fetch:
+        # Fall back to cache only when nothing fresh is in memory. _load_cache
+        # itself rejects anything older than the max age.
+        if not self.rates:
+            await self._load_cache()
+
+        # Fetch fresh rates when forced, or when we still have nothing fresh.
+        if force_refresh or not self.rates:
             fresh_rates = None
-            fetch_exception = None
             try:
                 _LOGGER.debug("Attempting to fetch fresh exchange rates from ECB.")
-                fresh_rates = await self._fetch_ecb_rates()  # Decorated with retry
+                fresh_rates = (
+                    await self._fetch_ecb_rates()
+                )  # retries; raises on failure
             except Exception as e:
-                fetch_exception = e  # Store exception
                 _LOGGER.warning("Fetching fresh ECB rates failed after retries: %s", e)
 
             if fresh_rates:
@@ -180,30 +241,30 @@ class ExchangeRateService:
                 self.rates = fresh_rates
                 self.last_update = now
                 await self._save_cache()
-                # Fall through to return self.rates
-            elif (
-                self.rates
-            ):  # Fetch failed, but we have rates (from memory or loaded cache)
-                _LOGGER.warning("Using existing rates as fresh fetch failed.")
-                # Fall through to return self.rates
-            else:  # Fetch failed AND we still have no rates
-                _LOGGER.error("Failed to fetch exchange rates and no cache available.")
-                # Raise the original exception if it exists, otherwise a generic one
-                if fetch_exception:
-                    raise fetch_exception  # Raise the original error (e.g. ClientConnectorError)
-                else:
-                    # Should not happen if fetch was attempted, but as a fallback
-                    raise ValueError(
-                        "Could not retrieve exchange rates (fetch attempt failed silently)"
-                    )
 
-        # Return rates (either fresh, loaded from cache, or from memory)
-        if not self.rates:
-            # This case should only be hit if fetch wasn't needed but rates are somehow empty.
-            _LOGGER.error("Exchange rates are unexpectedly empty after processing.")
-            raise ValueError("Exchange rates unavailable.")
+        # Fresh fetch succeeded, or a fresh (<= max age) cache was loaded above.
+        if self.rates:
+            return self.rates
 
+        # Nothing within the max age: do not risk wrong prices. Leave rates empty
+        # so currency conversion is skipped. The persistent cache (written on
+        # every successful fetch) and the scheduled handlers recover us as soon
+        # as ECB is reachable again.
+        _LOGGER.error(
+            "No exchange rates within %dh available (ECB unreachable and no "
+            "fresh cache). Currency conversion is paused; prices remain in their "
+            "source currency until ECB is reachable again.",
+            int(ECB.RATES_MAX_AGE_SECONDS // 3600),
+        )
+        self.rates = {}
+        self.last_update = 0
         return self.rates
+
+    def _rates_fresh(self):
+        """Return True if currently held rates are within the max age."""
+        if not self.rates:
+            return False
+        return (time.time() - self.last_update) <= ECB.RATES_MAX_AGE_SECONDS
 
     async def convert(self, amount, from_currency, to_currency):
         """Convert an amount from one currency to another."""
@@ -405,12 +466,25 @@ class ExchangeRateService:
 _EXCHANGE_SERVICE = None
 
 
-async def get_exchange_service(session=None):
-    """Get the exchange service singleton."""
+async def get_exchange_service(session=None, hass=None):
+    """Get the exchange service singleton.
+
+    When ``hass`` is provided we use Home Assistant's shared aiohttp session
+    (async_get_clientsession) instead of opening our own -- this follows the
+    inject-websession guidance and avoids blocking SSL certificate loading on the
+    event loop. The rate cache is stored under the HA config directory so it
+    survives container/add-on recreation (e.g. version upgrades). Without
+    ``hass`` (standalone scripts/tests), a home-directory path is used.
+    """
     global _EXCHANGE_SERVICE
 
     if _EXCHANGE_SERVICE is None:
-        _EXCHANGE_SERVICE = ExchangeRateService(session)
+        if session is None and hass is not None:
+            session = async_get_clientsession(hass)
+        cache_file = (
+            hass.config.path(EXCHANGE_RATE_CACHE_FILENAME) if hass is not None else None
+        )
+        _EXCHANGE_SERVICE = ExchangeRateService(session, cache_file=cache_file)
         await _EXCHANGE_SERVICE.get_rates()  # Initialize rates
 
     return _EXCHANGE_SERVICE

--- a/tests/pytest/unit/test_exchange_service.py
+++ b/tests/pytest/unit/test_exchange_service.py
@@ -34,7 +34,9 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.
 
 from custom_components.ge_spot.utils.exchange_service import (
     ExchangeRateService,
+    ExchangeRateFetchError,
     get_exchange_service,
+    EXCHANGE_RATE_CACHE_FILENAME,
 )
 from custom_components.ge_spot.const.currencies import Currency
 from custom_components.ge_spot.const.defaults import Defaults
@@ -184,25 +186,30 @@ async def test_convert_currency_caching(exchange_service):
 @pytest.mark.asyncio
 async def test_convert_currency_api_error(exchange_service):
     """Test handling of API errors with appropriate fallback."""
-    # Pre-populate cache with some rate data to test fallback
+    # Pre-populate fresh rates (1h old) to test fallback to existing rates
     exchange_service.rates = {Currency.EUR: 1.0, Currency.SEK: 10.0, Currency.USD: 1.1}
-    exchange_service.last_update = time.time() - 3600  # 1 hour ago
+    exchange_service.last_update = time.time() - 3600  # 1 hour ago (fresh)
 
     # Simulate API error by having _fetch_ecb_rates return None
     with patch.object(
         exchange_service, "_fetch_ecb_rates", AsyncMock(return_value=None)
     ):
-        # Act - Should use existing rates when fetch fails
+        # Act - Should keep existing (still-fresh) rates when fetch fails
         rates = await exchange_service.get_rates(force_refresh=True)
 
         # Assert fallback to existing rates
         assert rates is not None, "Should use existing rates"
         assert Currency.SEK in rates, "Existing rates should be preserved"
 
-        # But with no existing rates, should raise error
+        # With no existing rates and no fresh cache -> degrade to empty (never
+        # raise, never use stale rates).
         exchange_service.rates = {}
-        with pytest.raises(ValueError):
-            await exchange_service.get_rates(force_refresh=True)
+        exchange_service.last_update = 0
+        with patch.object(
+            exchange_service, "_load_cache", AsyncMock(return_value=False)
+        ):
+            rates = await exchange_service.get_rates(force_refresh=True)
+            assert rates == {}, "Should return empty rates when nothing is fresh"
 
 
 @pytest.mark.asyncio
@@ -235,17 +242,22 @@ async def test_convert_currency_network_error(exchange_service):
     with patch.object(
         exchange_service, "_fetch_ecb_rates", AsyncMock(side_effect=network_error)
     ):
-        # Act - Should use existing rates on error
+        # Act - Should keep existing (fresh) rates on error
         rates = await exchange_service.get_rates(force_refresh=True)
 
         # Assert
         assert rates is not None, "Should use existing rates"
         assert Currency.SEK in rates, "Existing rates should be preserved"
 
-        # But with empty rates, should propagate error
+        # With empty rates and no fresh cache, the network error is handled
+        # gracefully (never propagated) and conversion degrades to empty.
         exchange_service.rates = {}
-        with pytest.raises(ClientError):
-            await exchange_service.get_rates(force_refresh=True)
+        exchange_service.last_update = 0
+        with patch.object(
+            exchange_service, "_load_cache", AsyncMock(return_value=False)
+        ):
+            rates = await exchange_service.get_rates(force_refresh=True)
+            assert rates == {}, "Network error should degrade to empty, not raise"
 
 
 @pytest.mark.asyncio
@@ -363,8 +375,10 @@ async def test_get_exchange_rate_info(exchange_service):
 @pytest.mark.asyncio
 async def test_convert_currency_missing_rates(exchange_service):
     """Test error handling when rates are missing for requested currencies."""
-    # Arrange - set limited rates
+    # Arrange - set limited but FRESH rates so get_rates returns them as-is
+    # (stale rates would be discarded and replaced by cache/fallback).
     exchange_service.rates = {Currency.EUR: 1.0, Currency.USD: 1.1}
+    exchange_service.last_update = time.time()
 
     # Act & Assert - Missing target currency
     with pytest.raises(ValueError) as exc_info:
@@ -446,3 +460,205 @@ async def test_fetch_ecb_rates_uses_instance_session():
                 f"BUG DETECTED: Code uses undefined 'session' variable instead of 'self.session': {e}"
             )
         raise
+
+
+@pytest.mark.asyncio
+async def test_fetch_ecb_rates_raises_on_network_error():
+    """Regression (issue #68): _fetch_ecb_rates must propagate connection errors.
+
+    Previously the method caught the error and returned None, which silently
+    defeated @retry_with_backoff (it only retries on raised exceptions) and
+    surfaced the misleading "fetch attempt failed silently" ValueError.
+    """
+    service = ExchangeRateService()
+
+    # Session whose GET raises a connection error
+    mock_get = MagicMock()
+    mock_get.__aenter__ = AsyncMock(side_effect=ClientError("Cannot connect to host"))
+    mock_get.__aexit__ = AsyncMock(return_value=None)
+    mock_session = MagicMock()
+    mock_session.get = MagicMock(return_value=mock_get)
+    mock_session.close = AsyncMock()
+    service.session = mock_session
+
+    # Skip the backoff sleeps so the retries are instant
+    with patch(
+        "custom_components.ge_spot.api.base.error_handler.asyncio.sleep", AsyncMock()
+    ):
+        with pytest.raises(ClientError):
+            await service._fetch_ecb_rates()
+
+
+@pytest.mark.asyncio
+async def test_fetch_ecb_rates_raises_on_http_error():
+    """_fetch_ecb_rates raises (not returns None) on a non-200 response."""
+    service = ExchangeRateService()
+
+    mock_response = MagicMock()
+    mock_response.status = 500
+    mock_response.text = AsyncMock(return_value="error")
+    mock_get = MagicMock()
+    mock_get.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_get.__aexit__ = AsyncMock(return_value=None)
+    mock_session = MagicMock()
+    mock_session.get = MagicMock(return_value=mock_get)
+    mock_session.close = AsyncMock()
+    service.session = mock_session
+
+    with patch(
+        "custom_components.ge_spot.api.base.error_handler.asyncio.sleep", AsyncMock()
+    ):
+        with pytest.raises(ExchangeRateFetchError):
+            await service._fetch_ecb_rates()
+
+
+@pytest.mark.asyncio
+async def test_get_rates_uses_fresh_cache_when_fetch_fails(exchange_service):
+    """Failed fetch + a fresh (<= max age) cache -> the cache is used.
+
+    The persistent cache is the self-updating fallback: it is written on every
+    successful fetch and survives restarts/upgrades, so no hardcoded rates are
+    needed.
+    """
+    cached = {Currency.EUR: 1.0, Currency.SEK: 11.0, "USD": 1.1}
+
+    def fake_load_cache():
+        exchange_service.rates = dict(cached)
+        exchange_service.last_update = time.time() - 3600  # 1h old (fresh)
+        return True
+
+    exchange_service.rates = {}
+    exchange_service.last_update = 0
+    with patch.object(
+        exchange_service, "_load_cache", AsyncMock(side_effect=fake_load_cache)
+    ), patch.object(exchange_service, "_fetch_ecb_rates", AsyncMock(return_value=None)):
+        rates = await exchange_service.get_rates(force_refresh=True)
+
+    assert rates == cached, "Should use the fresh cached rates when fetch fails"
+
+
+@pytest.mark.asyncio
+async def test_get_rates_degrades_when_no_fresh_rates(exchange_service):
+    """No cache + failed fetch -> empty rates (conversion paused, never raises)."""
+    exchange_service.rates = {}
+    exchange_service.last_update = 0
+    with patch.object(
+        exchange_service, "_load_cache", AsyncMock(return_value=False)
+    ), patch.object(exchange_service, "_fetch_ecb_rates", AsyncMock(return_value=None)):
+        rates = await exchange_service.get_rates(force_refresh=True)
+
+    assert rates == {}, "Should degrade to empty rather than risk stale values"
+
+
+@pytest.mark.asyncio
+async def test_get_rates_discards_stale_in_memory_rates(exchange_service):
+    """In-memory rates older than the max age are discarded, never returned."""
+    exchange_service.rates = {Currency.EUR: 1.0, Currency.SEK: 10.0}
+    exchange_service.last_update = time.time() - (ECB.RATES_MAX_AGE_SECONDS + 3600)
+
+    with patch.object(
+        exchange_service, "_load_cache", AsyncMock(return_value=False)
+    ), patch.object(exchange_service, "_fetch_ecb_rates", AsyncMock(return_value=None)):
+        # Even a non-forced call must not return stale in-memory rates
+        rates = await exchange_service.get_rates(force_refresh=False)
+
+    assert rates == {}, "Stale in-memory rates must be discarded"
+
+
+@pytest.mark.asyncio
+async def test_load_cache_rejects_stale(exchange_service, tmp_path):
+    """Cache older than the max age is ignored (treated as a miss)."""
+    cache_file = tmp_path / "stale_rates.json"
+    stale_ts = time.time() - (ECB.RATES_MAX_AGE_SECONDS + 3600)
+    cache_file.write_text(
+        json.dumps(
+            {"rates": {Currency.EUR: 1.0, Currency.SEK: 10.0}, "timestamp": stale_ts}
+        )
+    )
+    exchange_service.cache_file = str(cache_file)
+    exchange_service.rates = {}
+
+    loaded = await exchange_service._load_cache()
+
+    assert loaded is False, "Stale cache should not load"
+    assert (
+        exchange_service.rates == {}
+    ), "Rates should remain empty after rejecting stale cache"
+
+
+@pytest.mark.asyncio
+async def test_load_cache_accepts_fresh(exchange_service, tmp_path):
+    """Cache within the max age loads normally."""
+    cache_file = tmp_path / "fresh_rates.json"
+    fresh_ts = time.time() - 3600  # 1h old
+    cache_file.write_text(
+        json.dumps(
+            {"rates": {Currency.EUR: 1.0, Currency.SEK: 10.0}, "timestamp": fresh_ts}
+        )
+    )
+    exchange_service.cache_file = str(cache_file)
+    exchange_service.rates = {}
+
+    loaded = await exchange_service._load_cache()
+
+    assert loaded is True
+    assert exchange_service.rates[Currency.SEK] == 10.0
+
+
+@pytest.mark.asyncio
+async def test_get_exchange_service_uses_shared_session_and_config_path():
+    """Factory uses HA's shared session (not its own) and the config-dir cache."""
+    import custom_components.ge_spot.utils.exchange_service as svc_module
+
+    # Ensure a clean singleton
+    svc_module._EXCHANGE_SERVICE = None
+
+    mock_hass = MagicMock()
+    expected_path = "/config/" + EXCHANGE_RATE_CACHE_FILENAME
+    mock_hass.config.path = MagicMock(return_value=expected_path)
+    shared_session = MagicMock()
+
+    with patch.object(ExchangeRateService, "get_rates", AsyncMock()), patch(
+        "custom_components.ge_spot.utils.exchange_service.async_get_clientsession",
+        return_value=shared_session,
+    ) as mock_gcs:
+        service = await get_exchange_service(hass=mock_hass)
+
+    # Uses the shared HA session, does not open its own, and won't close it
+    mock_gcs.assert_called_once_with(mock_hass)
+    assert service.session is shared_session
+    assert service._owns_session is False
+    # Cache stored under the HA config directory (survives upgrades)
+    assert service.cache_file == expected_path
+    mock_hass.config.path.assert_called_once_with(EXCHANGE_RATE_CACHE_FILENAME)
+
+    # Reset the singleton for other tests
+    svc_module._EXCHANGE_SERVICE = None
+
+
+@pytest.mark.asyncio
+async def test_close_only_closes_owned_session():
+    """close() closes a session we created, but never an injected (shared) one."""
+    # Injected session -> not owned -> must NOT be closed (HA manages it)
+    injected = MagicMock()
+    injected.close = AsyncMock()
+    svc = ExchangeRateService(session=injected)
+    assert svc._owns_session is False
+    await svc.close()
+    injected.close.assert_not_called()
+    assert svc.session is injected  # still usable by HA
+
+    # No session injected -> we create and own one -> close() closes it
+    svc2 = ExchangeRateService()
+    assert svc2._owns_session is True
+    created = MagicMock()
+    created.close = AsyncMock()
+    with patch(
+        "custom_components.ge_spot.utils.exchange_service.aiohttp.ClientSession",
+        return_value=created,
+    ):
+        await svc2._ensure_session()
+    assert svc2.session is created
+    await svc2.close()
+    created.close.assert_awaited_once()
+    assert svc2.session is None


### PR DESCRIPTION
## Problem (#68)
The integration **fails to set up entirely** when the ECB exchange-rate endpoint is briefly unreachable (`Cannot connect to host www.ecb.europa.eu:443 ssl:default [None]` → `ValueError: Could not retrieve exchange rates (fetch attempt failed silently)`).

I verified the ECB endpoint/URL itself is healthy — the failure is a transient client-side network blip that the integration turned into a hard setup failure. Two root causes plus a cache that didn't survive upgrades.

## Changes
- **`async_setup` no longer hard-fails** if rate init fails — the integration always loads; conversion degrades gracefully and retries.
- **`_fetch_ecb_rates` raises instead of swallowing errors** — the `@retry_with_backoff` decorator only retries on raised exceptions, so the old `return None` silently defeated retries and produced the misleading "fetch attempt failed silently" `ValueError`. The real cause now surfaces.
- **24-hour freshness rule** — `get_rates` resolves *fresh ECB → persistent cache (≤24h)*; rates older than 24h (in memory or cache) are discarded. When nothing fresh is available, conversion is **paused** (prices stay in source currency) rather than using stale/wrong rates. Never raises.
- **Cache persisted under `hass.config.path()`** so it survives container/add-on recreation on upgrades (the reason reverting versions didn't help the reporter).
- **HA-async compliance for this service**: use `async_get_clientsession` (no own session / blocking SSL cert load) with session-ownership tracking, and drop the blocking `os.stat` calls from cache load.

No bundled/hardcoded fallback rates — the self-updating persistent cache is the fallback.

## Testing
- 428 unit tests passing (`tests/pytest/unit/`), black-clean.
- Verified live against the real ECB API, and reproduced the exact #68 outage scenario (now degrades gracefully, no exception).

Fixes #68
