### PR TITLE
Avoid blocking I/O on the event loop (cache + API client)

### DIFF
--- a/custom_components/ge_spot/api/aemo.py
+++ b/custom_components/ge_spot/api/aemo.py
@@ -200,25 +200,12 @@ class AemoAPI(BasePriceAPI):
         try:
             timeout_obj = aiohttp.ClientTimeout(total=Network.Defaults.HTTP_TIMEOUT * 2)
 
-            if client.session:
-                # Use existing session
-                async with client.session.get(url, timeout=timeout_obj) as response:
-                    if response.status != 200:
-                        _LOGGER.error(
-                            f"Failed to download {url}: HTTP {response.status}"
-                        )
-                        return None
-                    return await response.read()
-            else:
-                # Create temporary session
-                async with aiohttp.ClientSession() as temp_session:
-                    async with temp_session.get(url, timeout=timeout_obj) as response:
-                        if response.status != 200:
-                            _LOGGER.error(
-                                f"Failed to download {url}: HTTP {response.status}"
-                            )
-                            return None
-                        return await response.read()
+            # client.session is always an injected (shared) HA session
+            async with client.session.get(url, timeout=timeout_obj) as response:
+                if response.status != 200:
+                    _LOGGER.error(f"Failed to download {url}: HTTP {response.status}")
+                    return None
+                return await response.read()
 
         except Exception as e:
             _LOGGER.error(

--- a/custom_components/ge_spot/api/base/api_client.py
+++ b/custom_components/ge_spot/api/base/api_client.py
@@ -14,15 +14,22 @@ _LOGGER = logging.getLogger(__name__)
 class ApiClient:
     """Generic API client with improved error handling."""
 
-    def __init__(
-        self, session: Optional[aiohttp.ClientSession] = None, pool_size: int = 10
-    ):
+    def __init__(self, session: aiohttp.ClientSession, pool_size: int = 10):
         """Initialize the API client.
 
         Args:
-            session: Optional aiohttp ClientSession to use
+            session: aiohttp ClientSession to use. Required -- callers inject
+                Home Assistant's shared session via async_get_clientsession(hass)
+                rather than letting the client open its own. Opening a session
+                here would block the event loop loading SSL certs and is
+                discouraged by HA's inject-websession quality rule.
             pool_size: Size of the connection pool
         """
+        if session is None:
+            raise ValueError(
+                "ApiClient requires an aiohttp session; inject "
+                "async_get_clientsession(hass) instead of creating one."
+            )
         self.session = session
         self.pool_size = pool_size
         self._semaphore = asyncio.Semaphore(pool_size)
@@ -56,86 +63,40 @@ class ApiClient:
 
         async with self._semaphore:
             try:
-                if self.session:
-                    async with self.session.get(
-                        url, params=params, headers=merged_headers, timeout=timeout_obj
-                    ) as response:
-                        # HTTP 204 = No Content - data not published yet (not an error)
-                        if response.status == 204:
-                            _LOGGER.info(
-                                f"API returned 204 (No Content) - data not yet published: {url}"
-                            )
-                            return {"status": 204, "message": "Data not yet published"}
+                async with self.session.get(
+                    url, params=params, headers=merged_headers, timeout=timeout_obj
+                ) as response:
+                    # HTTP 204 = No Content - data not published yet (not an error)
+                    if response.status == 204:
+                        _LOGGER.info(
+                            f"API returned 204 (No Content) - data not yet published: {url}"
+                        )
+                        return {"status": 204, "message": "Data not yet published"}
 
-                        if response.status != 200:
-                            _LOGGER.error(
-                                f"API request failed with status {response.status}: {url}"
-                            )
-                            return {}
+                    if response.status != 200:
+                        _LOGGER.error(
+                            f"API request failed with status {response.status}: {url}"
+                        )
+                        return {}
 
-                        # Check content type to determine how to parse the response
-                        content_type = response.headers.get("Content-Type", "").lower()
+                    # Check content type to determine how to parse the response
+                    content_type = response.headers.get("Content-Type", "").lower()
 
-                        if "application/json" in content_type:
+                    if "application/json" in content_type:
+                        return await response.json()
+                    elif (
+                        "text/xml" in content_type or "application/xml" in content_type
+                    ):
+                        return await response.text(encoding=encoding)
+                    else:
+                        # Try JSON first, fall back to text if that fails.
+                        # Narrow the catch so KeyboardInterrupt/SystemExit propagate:
+                        #   ContentTypeError = Content-Type didn't match application/json
+                        #   JSONDecodeError  = body wasn't valid JSON
+                        try:
                             return await response.json()
-                        elif (
-                            "text/xml" in content_type
-                            or "application/xml" in content_type
-                        ):
+                        except (aiohttp.ContentTypeError, json.JSONDecodeError):
                             return await response.text(encoding=encoding)
-                        else:
-                            # Try JSON first, fall back to text if that fails.
-                            # Narrow the catch so KeyboardInterrupt/SystemExit propagate:
-                            #   ContentTypeError = Content-Type didn't match application/json
-                            #   JSONDecodeError  = body wasn't valid JSON
-                            try:
-                                return await response.json()
-                            except (aiohttp.ContentTypeError, json.JSONDecodeError):
-                                return await response.text(encoding=encoding)
-                else:
-                    async with aiohttp.ClientSession() as session:
-                        async with session.get(
-                            url,
-                            params=params,
-                            headers=merged_headers,
-                            timeout=timeout_obj,
-                        ) as response:
-                            # HTTP 204 = No Content - data not published yet (not an error)
-                            if response.status == 204:
-                                _LOGGER.info(
-                                    f"API returned 204 (No Content) - data not yet published: {url}"
-                                )
-                                return {
-                                    "status": 204,
-                                    "message": "Data not yet published",
-                                }
-
-                            if response.status != 200:
-                                _LOGGER.error(
-                                    f"API request failed with status {response.status}: {url}"
-                                )
-                                return {}
-
-                            # Check content type to determine how to parse the response
-                            content_type = response.headers.get(
-                                "Content-Type", ""
-                            ).lower()
-
-                            if "application/json" in content_type:
-                                return await response.json()
-                            elif (
-                                "text/xml" in content_type
-                                or "application/xml" in content_type
-                            ):
-                                return await response.text(encoding=encoding)
-                            else:
-                                # Try JSON first, fall back to text if that fails.
-                                # See the matching block above for why these
-                                # exception types are the right ones to catch.
-                                try:
-                                    return await response.json()
-                                except (aiohttp.ContentTypeError, json.JSONDecodeError):
-                                    return await response.text(encoding=encoding)
             except asyncio.TimeoutError:
                 _LOGGER.error(f"API request timed out: {url}")
                 return {}
@@ -182,150 +143,74 @@ class ApiClient:
 
         async with self._semaphore:
             try:
-                if self.session:
-                    async with self.session.get(
-                        url, params=params, headers=merged_headers, timeout=timeout_obj
-                    ) as response:
-                        # Check for HTTP errors
-                        if response.status != 200:
-                            # Track consecutive errors for rate limit detection
-                            self._track_error_response(url, response.status)
+                async with self.session.get(
+                    url, params=params, headers=merged_headers, timeout=timeout_obj
+                ) as response:
+                    # Check for HTTP errors
+                    if response.status != 200:
+                        # Track consecutive errors for rate limit detection
+                        self._track_error_response(url, response.status)
 
-                            _LOGGER.error(
-                                f"API request failed with status {response.status}: {url}"
-                            )
+                        _LOGGER.error(
+                            f"API request failed with status {response.status}: {url}"
+                        )
 
-                            # Try to get more detailed error information
-                            try:
-                                error_text = await response.text(encoding=encoding)
-                                # Return error information instead of empty dict
-                                return {
-                                    "error": True,
-                                    "status_code": response.status,
-                                    "message": (
-                                        error_text[:500]
-                                        if len(error_text) > 500
-                                        else error_text
-                                    ),
-                                    "url": url,
-                                }
-                            except Exception as e:
-                                _LOGGER.debug(f"Could not extract error text: {e}")
-                                # Fallback error info
-                                return {
-                                    "error": True,
-                                    "status_code": response.status,
-                                    "message": f"HTTP {response.status}",
-                                    "url": url,
-                                }
+                        # Try to get more detailed error information
+                        try:
+                            error_text = await response.text(encoding=encoding)
+                            # Return error information instead of empty dict
+                            return {
+                                "error": True,
+                                "status_code": response.status,
+                                "message": (
+                                    error_text[:500]
+                                    if len(error_text) > 500
+                                    else error_text
+                                ),
+                                "url": url,
+                            }
+                        except Exception as e:
+                            _LOGGER.debug(f"Could not extract error text: {e}")
+                            # Fallback error info
+                            return {
+                                "error": True,
+                                "status_code": response.status,
+                                "message": f"HTTP {response.status}",
+                                "url": url,
+                            }
 
-                        # Success - reset error tracking
-                        self._reset_error_tracking(url)
+                    # Success - reset error tracking
+                    self._reset_error_tracking(url)
 
-                        # Process successful response based on format parameter or content type
-                        if response_format:
-                            if response_format.lower() in ["text", "csv"]:
-                                return await response.text(encoding=encoding)
-                            elif response_format.lower() == "json":
-                                return await response.json()
-                            elif response_format.lower() == "xml":
-                                return await response.text(encoding=encoding)
-
-                        # If no specific format requested, check content type
-                        content_type = response.headers.get("Content-Type", "").lower()
-
-                        if "application/json" in content_type:
+                    # Process successful response based on format parameter or content type
+                    if response_format:
+                        if response_format.lower() in ["text", "csv"]:
+                            return await response.text(encoding=encoding)
+                        elif response_format.lower() == "json":
                             return await response.json()
-                        elif (
-                            "text/xml" in content_type
-                            or "application/xml" in content_type
-                        ):
+                        elif response_format.lower() == "xml":
                             return await response.text(encoding=encoding)
-                        elif "text/csv" in content_type or "text/plain" in content_type:
+
+                    # If no specific format requested, check content type
+                    content_type = response.headers.get("Content-Type", "").lower()
+
+                    if "application/json" in content_type:
+                        return await response.json()
+                    elif (
+                        "text/xml" in content_type or "application/xml" in content_type
+                    ):
+                        return await response.text(encoding=encoding)
+                    elif "text/csv" in content_type or "text/plain" in content_type:
+                        return await response.text(encoding=encoding)
+                    else:
+                        # Try JSON first, fall back to text if that fails.
+                        # Narrow the catch so KeyboardInterrupt/SystemExit propagate:
+                        #   ContentTypeError = Content-Type didn't match application/json
+                        #   JSONDecodeError  = body wasn't valid JSON
+                        try:
+                            return await response.json()
+                        except (aiohttp.ContentTypeError, json.JSONDecodeError):
                             return await response.text(encoding=encoding)
-                        else:
-                            # Try JSON first, fall back to text if that fails.
-                            # Narrow the catch so KeyboardInterrupt/SystemExit propagate:
-                            #   ContentTypeError = Content-Type didn't match application/json
-                            #   JSONDecodeError  = body wasn't valid JSON
-                            try:
-                                return await response.json()
-                            except (aiohttp.ContentTypeError, json.JSONDecodeError):
-                                return await response.text(encoding=encoding)
-                else:
-                    # Create temporary session if none exists
-                    async with aiohttp.ClientSession() as session:
-                        async with session.get(
-                            url,
-                            params=params,
-                            headers=merged_headers,
-                            timeout=timeout_obj,
-                        ) as response:
-                            if response.status != 200:
-                                # Track consecutive errors for rate limit detection
-                                self._track_error_response(url, response.status)
-
-                                _LOGGER.error(
-                                    f"API request failed with status {response.status}: {url}"
-                                )
-
-                                try:
-                                    error_text = await response.text(encoding=encoding)
-                                    return {
-                                        "error": True,
-                                        "status_code": response.status,
-                                        "message": (
-                                            error_text[:500]
-                                            if len(error_text) > 500
-                                            else error_text
-                                        ),
-                                        "url": url,
-                                    }
-                                except Exception as e:
-                                    _LOGGER.debug(f"Could not extract error text: {e}")
-                                    return {
-                                        "error": True,
-                                        "status_code": response.status,
-                                        "message": f"HTTP {response.status}",
-                                        "url": url,
-                                    }
-
-                            # Success - reset error tracking
-                            self._reset_error_tracking(url)
-
-                            # Process successful response based on format parameter or content type
-                            if response_format:
-                                if response_format.lower() in ["text", "csv"]:
-                                    return await response.text(encoding=encoding)
-                                elif response_format.lower() == "json":
-                                    return await response.json()
-                                elif response_format.lower() == "xml":
-                                    return await response.text(encoding=encoding)
-
-                            # If no specific format requested, check content type
-                            content_type = response.headers.get(
-                                "Content-Type", ""
-                            ).lower()
-
-                            if "application/json" in content_type:
-                                return await response.json()
-                            elif (
-                                "text/xml" in content_type
-                                or "application/xml" in content_type
-                            ):
-                                return await response.text(encoding=encoding)
-                            elif (
-                                "text/csv" in content_type
-                                or "text/plain" in content_type
-                            ):
-                                return await response.text(encoding=encoding)
-                            else:
-                                # Try JSON first, fall back to text if that fails.
-                                # See the matching block in get() for rationale.
-                                try:
-                                    return await response.json()
-                                except (aiohttp.ContentTypeError, json.JSONDecodeError):
-                                    return await response.text(encoding=encoding)
             except asyncio.TimeoutError:
                 _LOGGER.error(f"API request timed out: {url}")
                 return {"error": True, "message": "Request timed out", "url": url}
@@ -384,6 +269,10 @@ class ApiClient:
             del self._rate_limit_detected[url_key]
 
     async def close(self) -> None:
-        """Close the session if it was created by this instance."""
-        if self.session and not hasattr(self.session, "_is_external"):
-            await self.session.close()
+        """No-op: the aiohttp session is injected and owned by the caller.
+
+        The session comes from Home Assistant's async_get_clientsession and is
+        shared across the integration (and others), so this client must never
+        close it. Kept so existing call sites remain valid.
+        """
+        return

--- a/custom_components/ge_spot/utils/advanced_cache.py
+++ b/custom_components/ge_spot/utils/advanced_cache.py
@@ -128,9 +128,10 @@ class AdvancedCache:
         # Cache storage
         self._cache: Dict[str, CacheEntry] = {}
 
-        # Load cache from disk if enabled
+        # Load cache from disk if enabled. Run on the executor so the blocking
+        # file I/O (open/os.stat) never runs on the event loop.
         if self.persist_cache and hass:
-            self._load_cache()
+            hass.async_add_executor_job(self._load_cache)
 
     def get(self, key: str, default: Any = None) -> Any:
         """Get a value from the cache.
@@ -185,9 +186,10 @@ class AdvancedCache:
         # Check if we need to evict entries
         self._evict_if_needed()
 
-        # Persist cache if enabled
+        # Persist cache if enabled. Schedule on the executor so the blocking
+        # file I/O never runs on the event loop.
         if self.persist_cache and self.hass:
-            self._save_cache()
+            self.hass.async_add_executor_job(self._save_cache)
 
     def delete(self, key: str) -> bool:
         """Delete a value from the cache.
@@ -201,9 +203,10 @@ class AdvancedCache:
         if key in self._cache:
             del self._cache[key]
 
-            # Persist cache if enabled
+            # Persist cache if enabled. Schedule on the executor so the blocking
+            # file I/O never runs on the event loop.
             if self.persist_cache and self.hass:
-                self._save_cache()
+                self.hass.async_add_executor_job(self._save_cache)
 
             return True
 
@@ -213,9 +216,10 @@ class AdvancedCache:
         """Clear the cache."""
         self._cache.clear()
 
-        # Persist cache if enabled
+        # Persist cache if enabled. Schedule on the executor so the blocking
+        # file I/O never runs on the event loop.
         if self.persist_cache and self.hass:
-            self._save_cache()
+            self.hass.async_add_executor_job(self._save_cache)
 
     def get_info(self) -> Dict[str, Any]:
         """Get information about the cache.

--- a/tests/pytest/integration/test_amber_live.py
+++ b/tests/pytest/integration/test_amber_live.py
@@ -1,6 +1,7 @@
 import pytest
 import os
 import logging
+import aiohttp
 from datetime import datetime, timedelta
 
 from custom_components.ge_spot.api.amber import AmberAPI
@@ -26,12 +27,14 @@ async def test_amber_live_fetch_parse():
     If it fails, investigate and fix the core code rather than modifying the test.
     """
     logger.info("Testing Amber live API...")
-    # Arrange - don't catch exceptions during setup
+    # Arrange - don't catch exceptions during setup. Inject a session (the
+    # client requires one and never opens its own).
     api = AmberAPI()
+    session = aiohttp.ClientSession()
 
     try:
         # Act: Fetch Raw Data - let exceptions propagate to find real issues
-        raw_data = await api.fetch_raw_data()
+        raw_data = await api.fetch_raw_data(session=session)
 
         # Assert: Raw Data Structure (strict validation)
         assert raw_data is not None, "Raw data should not be None"
@@ -180,5 +183,4 @@ async def test_amber_live_fetch_parse():
         logger.error(f"Amber Live Test: EXCEPTION - {str(e)}")
         raise
     finally:
-        if hasattr(api, "session") and api.session:
-            await api.session.close()
+        await session.close()

--- a/tests/pytest/integration/test_energi_data_live.py
+++ b/tests/pytest/integration/test_energi_data_live.py
@@ -2,6 +2,7 @@ import pytest
 import logging
 from datetime import datetime, timedelta
 import asyncio
+import aiohttp
 
 from custom_components.ge_spot.api.energi_data import EnergiDataAPI
 from custom_components.ge_spot.const.sources import Source
@@ -31,13 +32,15 @@ async def test_energi_data_live_fetch_parse(area):
     If it fails, investigate and fix the core code rather than modifying the test.
     """
     logger.info(f"Testing Energi Data Service live API for area: {area}...")
-    # Arrange - allow failures during setup to find real issues
+    # Arrange - allow failures during setup to find real issues. Inject a
+    # session (the client requires one and never opens its own).
     api = EnergiDataAPI()
+    session = aiohttp.ClientSession()
     session_closed = False
 
     try:
         # Act: Fetch Raw Data - no exception handling to expose real issues
-        raw_data = await api.fetch_raw_data(area=area)
+        raw_data = await api.fetch_raw_data(area=area, session=session)
 
         # Assert: Raw Data Structure (strict validation)
         assert raw_data is not None, f"Raw data for {area} should not be None"
@@ -186,10 +189,10 @@ async def test_energi_data_live_fetch_parse(area):
         logger.error(f"Energi Data Service Live Test ({area}): EXCEPTION - {str(e)}")
         raise
     finally:
-        # Proper async cleanup
-        if hasattr(api, "session") and api.session and not session_closed:
+        # Proper async cleanup of the injected session
+        if not session_closed:
             try:
-                await api.session.close()
+                await session.close()
                 session_closed = True
                 # Give a moment for the session to fully close
                 await asyncio.sleep(0.1)


### PR DESCRIPTION
## Why
Follow-up to the exchange-rate PR. An audit against the current HA developer docs ([blocking operations](https://developers.home-assistant.io/docs/asyncio_blocking_operations/), [inject-websession](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/inject-websession/)) found the same patterns elsewhere. None were hit in the **default** production path (the session ones are fallbacks — HA always injects the shared session; the cache I/O is behind `persist_cache=False`), but this hardens them so zero doc-flagged patterns remain.

## Changes
- **`AdvancedCache`**: schedule the persist-cache disk I/O (`open`/`os.makedirs`/`os.stat`) via `hass.async_add_executor_job` so it never blocks the event loop when `persist_cache` is enabled.
- **`ApiClient`**: require an injected `aiohttp` session; remove the per-request `aiohttp.ClientSession()` fallback (which blocks the loop loading SSL certs and violates inject-websession). Removes ~60 lines of duplicated branch code.
- **`ApiClient.close()` → no-op**, fixing a **latent bug**: `_is_external` was checked but never set, so `close()` would close HA's *shared* session. The injected session is owned by HA and must never be closed here.
- **AEMO `_download_binary_file`**: drop the temporary-session branch.
- **Live tests** (`amber`, `energi_data`): inject a session instead of relying on the removed fallback.

## Testing
- 419 unit tests passing, black-clean.
- Production path unaffected (the coordinator already injects `async_get_clientsession(hass)` into every API call).
