### PR TITLE
Add base market-price sensors (before VAT/taxes/tariffs) (#70)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,6 +14,7 @@ Home Assistant custom integration providing 15-minute electricity spot prices ac
 8. **Ask before acting** - When uncertain, clarify first
 9. **No analysis/summary files in git** - All `*ANALYSIS*.md`, `*SUMMARY*.md` files stay untracked
 10. **Format with black** - Run `black` on all Python code before committing. Consistent formatting is mandatory.
+11. **No AI attribution** - Never add AI/assistant attribution to commits, PRs, or code. No "Generated with Claude Code", no "Co-Authored-By: Claude", no robot-emoji trailers, no "AI"/"Copilot"/"assistant" credit anywhere.
 
 ## Architecture
 

--- a/custom_components/ge_spot/coordinator/data_models.py
+++ b/custom_components/ge_spot/coordinator/data_models.py
@@ -263,6 +263,28 @@ class IntervalPriceData:
             return None
 
     @property
+    def current_raw_price(self) -> Optional[float]:
+        """Get current interval base market price (before VAT/taxes/tariffs).
+
+        Mirrors current_price but reads the raw (pre-VAT/tariff) values, so a
+        sensor can expose the underlying spot market price even when VAT and
+        tariffs are configured (Issue #70).
+
+        Returns:
+            Current base market price or None if not available
+        """
+        if not self._tz_service:
+            _LOGGER.warning("Cannot get current_raw_price without timezone service")
+            return None
+
+        try:
+            current_key = self._tz_service.get_current_interval_key()
+            return self.today_raw_prices.get(current_key)
+        except Exception as e:
+            _LOGGER.error(f"Error getting current_raw_price: {e}", exc_info=True)
+            return None
+
+    @property
     def next_interval_price(self) -> Optional[float]:
         """Get next interval price.
 

--- a/custom_components/ge_spot/sensor/electricity.py
+++ b/custom_components/ge_spot/sensor/electricity.py
@@ -229,6 +229,37 @@ async def async_setup_entry(
     )
     # --- End Hourly Average Sensors ---
 
+    # --- Base Market Price Sensors (Issue #70) ---
+    # The underlying spot market price BEFORE VAT/taxes/tariffs (from raw
+    # prices), so users who configure VAT/tariffs can still see the market price
+    # alongside the all-in price.
+
+    # Current Market Price (current 15-minute interval, no VAT/taxes/tariffs)
+    get_current_market_price = lambda data: data.current_raw_price if data else None
+    entities.append(
+        PriceValueSensor(
+            coordinator,
+            config_data,
+            "current_market_price",
+            "Current Market Price",
+            get_current_market_price,
+            get_base_attrs,
+        )
+    )
+
+    # Hourly Market Average Price (current hour average, no VAT/taxes/tariffs)
+    entities.append(
+        HourlyAverageSensor(
+            coordinator,
+            config_data,
+            "hourly_market_average_price",
+            "Hourly Market Average Price",
+            day_offset=0,
+            use_raw=True,
+        )
+    )
+    # --- End Base Market Price Sensors ---
+
     # --- Export/Production Price Sensors ---
     # Only add export sensors if export is enabled in config
     export_enabled = options.get(

--- a/custom_components/ge_spot/sensor/price.py
+++ b/custom_components/ge_spot/sensor/price.py
@@ -416,7 +416,13 @@ class HourlyAverageSensor(PriceValueSensor):
     )
 
     def __init__(
-        self, coordinator, config_data, sensor_type, name_suffix, day_offset=0
+        self,
+        coordinator,
+        config_data,
+        sensor_type,
+        name_suffix,
+        day_offset=0,
+        use_raw=False,
     ):
         """Initialize the hourly average price sensor.
 
@@ -426,8 +432,11 @@ class HourlyAverageSensor(PriceValueSensor):
             sensor_type: Type identifier for the sensor
             name_suffix: Display name suffix
             day_offset: 0 for today, 1 for tomorrow
+            use_raw: If True, average the base market prices (raw, before
+                VAT/taxes/tariffs) instead of the all-in prices (Issue #70)
         """
         self._day_offset = day_offset
+        self._use_raw = use_raw
 
         # Create value extraction function
         def extract_value(data):
@@ -473,11 +482,20 @@ class HourlyAverageSensor(PriceValueSensor):
         Returns:
             Dictionary mapping hour (HH:00) to average price
         """
-        # Get the appropriate interval prices based on day offset
-        if self._day_offset == 0:
-            interval_prices = data.today_interval_prices if data else {}
+        # Get the appropriate interval prices based on day offset. When use_raw
+        # is set, use the base market prices (before VAT/taxes/tariffs).
+        if not data:
+            interval_prices = {}
+        elif self._day_offset == 0:
+            interval_prices = (
+                data.today_raw_prices if self._use_raw else data.today_interval_prices
+            )
         else:
-            interval_prices = data.tomorrow_interval_prices if data else {}
+            interval_prices = (
+                data.tomorrow_raw_prices
+                if self._use_raw
+                else data.tomorrow_interval_prices
+            )
 
         if not interval_prices:
             return {}
@@ -566,15 +584,17 @@ class HourlyAverageSensor(PriceValueSensor):
         today_hourly = {}
         tomorrow_hourly = {}
 
-        # Get interval prices from coordinator data (properties)
-        today_intervals = (
-            self.coordinator.data.today_interval_prices if self.coordinator.data else {}
-        )
-        tomorrow_intervals = (
-            self.coordinator.data.tomorrow_interval_prices
-            if self.coordinator.data
-            else {}
-        )
+        # Get interval prices from coordinator data (properties). When use_raw
+        # is set, use the base market prices (before VAT/taxes/tariffs).
+        if not self.coordinator.data:
+            today_intervals = {}
+            tomorrow_intervals = {}
+        elif self._use_raw:
+            today_intervals = self.coordinator.data.today_raw_prices
+            tomorrow_intervals = self.coordinator.data.tomorrow_raw_prices
+        else:
+            today_intervals = self.coordinator.data.today_interval_prices
+            tomorrow_intervals = self.coordinator.data.tomorrow_interval_prices
 
         # Calculate hourly averages for today
         if today_intervals:

--- a/tests/pytest/unit/test_data_models.py
+++ b/tests/pytest/unit/test_data_models.py
@@ -160,6 +160,27 @@ class TestComputedProperties:
 
         assert data.current_price is None
 
+    def test_current_raw_price_lookup(self, sample_today_prices, mock_timezone_service):
+        """Test current_raw_price reads the base market price (Issue #70)."""
+        # Make raw prices distinct from the all-in prices so we prove it reads
+        # the raw (pre-VAT/tariff) values rather than the converted ones.
+        raw_prices = {k: v - 50.0 for k, v in sample_today_prices.items()}
+        data = IntervalPriceData(
+            today_interval_prices=sample_today_prices,
+            today_raw_prices=raw_prices,
+            _tz_service=mock_timezone_service,
+        )
+
+        # Current interval is 14:15: all-in = 114.0, base market = 64.0
+        assert data.current_price == 114.0
+        assert data.current_raw_price == 64.0
+
+    def test_current_raw_price_none_without_tz_service(self, sample_today_prices):
+        """Test current_raw_price returns None without timezone service."""
+        data = IntervalPriceData(today_raw_prices=sample_today_prices)
+
+        assert data.current_raw_price is None
+
     def test_next_interval_price_lookup(
         self, sample_today_prices, mock_timezone_service
     ):

--- a/tests/pytest/unit/test_hourly_average_sensor.py
+++ b/tests/pytest/unit/test_hourly_average_sensor.py
@@ -723,3 +723,92 @@ class TestHourlyAverageSensor:
         assert "today_min_price" not in attrs
         assert "today_max_price" not in attrs
         assert "today_avg_price" not in attrs
+
+    def test_use_raw_averages_base_market_prices(self, config_data):
+        """use_raw=True averages base market prices, not the all-in prices.
+
+        Issue #70: a dedicated 1-hour sensor for the market price (before
+        VAT/taxes/tariffs) when those adjustments are configured.
+        """
+        coordinator = Mock()
+        coordinator.data = IntervalPriceData(
+            today_interval_prices={
+                "00:00": 110.0,
+                "00:15": 112.0,
+                "00:30": 114.0,
+                "00:45": 116.0,
+            },
+            today_raw_prices={
+                "00:00": 10.0,
+                "00:15": 12.0,
+                "00:30": 14.0,
+                "00:45": 16.0,
+            },
+            source="nordpool",
+            area="SE3",
+        )
+        coordinator.last_update_success = True
+
+        # Default (all-in) averages the converted prices: (110+112+114+116)/4
+        all_in = HourlyAverageSensor(
+            coordinator,
+            config_data,
+            "hourly_average_price",
+            "Hourly Average Price",
+            day_offset=0,
+        )
+        assert all_in._calculate_hourly_averages(coordinator.data)["00:00"] == 113.0
+
+        # use_raw averages the base market prices: (10+12+14+16)/4 = 13.0
+        market = HourlyAverageSensor(
+            coordinator,
+            config_data,
+            "hourly_market_average_price",
+            "Hourly Market Average Price",
+            day_offset=0,
+            use_raw=True,
+        )
+        assert market._calculate_hourly_averages(coordinator.data)["00:00"] == 13.0
+
+    @patch("custom_components.ge_spot.sensor.base.dt_util.get_default_time_zone")
+    def test_use_raw_attributes_use_base_prices(self, mock_get_tz, config_data):
+        """use_raw=True hourly attributes expose base market prices (Issue #70)."""
+        mock_get_tz.return_value = timezone.utc
+
+        coordinator = Mock()
+        coordinator.data = IntervalPriceData(
+            today_interval_prices={
+                "00:00": 110.0,
+                "00:15": 112.0,
+                "00:30": 114.0,
+                "00:45": 116.0,
+            },
+            today_raw_prices={
+                "00:00": 10.0,
+                "00:15": 12.0,
+                "00:30": 14.0,
+                "00:45": 16.0,
+            },
+            source="nordpool",
+            area="SE3",
+        )
+        coordinator.last_update_success = True
+
+        sensor = HourlyAverageSensor(
+            coordinator,
+            config_data,
+            "hourly_market_average_price",
+            "Hourly Market Average Price",
+            day_offset=0,
+            use_raw=True,
+        )
+        sensor._tz_service = None
+
+        attrs = sensor.extra_state_attributes
+
+        # Hourly list reflects the base market average (13.0), not all-in (113.0)
+        today_hourly = attrs["today_hourly_prices"]
+        hour_0 = next((e for e in today_hourly if e["time"].hour == 0), None)
+        assert hour_0 is not None
+        assert abs(hour_0["value"] - 13.0) < 0.0001
+        assert attrs["today_avg_price"] == 13.0


### PR DESCRIPTION
## Problem (#70)
When VAT and additional tariffs are configured, the price sensors show the calculated all-in value, with **no sensor exposing the base market (spot) price**. Users who want the underlying market price have to recompute it themselves.

## Approach
The base price already flows through the whole pipeline — `convert_interval_prices()` returns `raw_prices` (currency+unit converted, but **before** VAT/taxes/tariffs), stored as `today_raw_prices` / `tomorrow_raw_prices` and even migrated across midnight. This PR just **surfaces it as two sensors**, mirroring the existing `current_price` / `hourly_average_price`:

- **Current Market Price** — `sensor.gespot_current_market_price_<area>` (current 15-min interval, base price)
- **Hourly Market Average Price** — `sensor.gespot_hourly_market_average_price_<area>` (current hour average, base price)

## Changes
- `coordinator/data_models.py`: add `current_raw_price` property (mirrors `current_price`, reads `today_raw_prices`).
- `sensor/price.py`: `HourlyAverageSensor` gains a `use_raw` flag to average the base prices (both the value and the hourly attributes); default behavior unchanged.
- `sensor/electricity.py`: register the two new sensors.

No new constants/translations needed — names use the existing `name_suffix` mechanism, consistent with all other sensors.

## Testing
- **Unit**: 423 passing (+4 new) — `current_raw_price` lookup, raw hourly averaging, and raw hourly attributes.
- **Live (real Home Assistant)**: configured SE4 with **VAT = 25%**:
  - `current_price` (all-in) = `2.0617396125` SEK/kWh
  - `current_market_price` (new) = `1.64939169` → ×1.25 = `2.0617396125` ✓
  - `hourly_average_price` (all-in) = `2.336942625`
  - `hourly_market_average_price` (new) = `1.8695541` → ×1.25 = `2.336942625` ✓

  The new sensors show exactly the pre-VAT market price; the all-in sensors are exactly 1.25× (the VAT factor). 14 entities total (12 + 2 new).

Closes #70
