### PR TITLE
Fix PricePercentSensor device_class (monetary mismatch with '%' unit)

### DIFF
--- a/custom_components/ge_spot/sensor/price.py
+++ b/custom_components/ge_spot/sensor/price.py
@@ -322,7 +322,9 @@ class PriceDifferenceSensor(PriceValueSensor):
 class PricePercentSensor(PriceValueSensor):
     """Sensor for price percentage relative to a reference value."""
 
-    device_class = SensorDeviceClass.MONETARY
+    # A percentage (unit "%") is not a monetary amount; MONETARY here is a
+    # device_class/unit mismatch. Override the base MONETARY device_class to None.
+    device_class = None
     state_class = None
 
     def __init__(


### PR DESCRIPTION
## Summary
`PricePercentSensor` exposes a **percentage** (price relative to the day's average, unit `%`) but was declared `device_class = SensorDeviceClass.MONETARY`. MONETARY denotes a currency *amount*, so pairing it with a `%` unit is a device_class/unit mismatch (the value is not money).

Fix: set `device_class = None` for this sensor. The genuine price sensors are untouched and keep `MONETARY` + `<currency>/kWh`.

## Before / After (live HA, SE4)
| | device_class | unit |
|---|---|---|
| `sensor.gespot_price_percentage_se4` (before) | `monetary` | `%` |
| `sensor.gespot_price_percentage_se4` (after) | `null` | `%` |
| `sensor.gespot_current_price_se4` (unchanged) | `monetary` | `SEK/kWh` |

## Testing
- `python -m pytest tests/pytest/unit/` → **432 passed**.
- **Live HA (real instance + debug logging):** confirmed the percentage sensor now reports `device_class=null` (unit `%`); the 13 price sensors remain `monetary` — exactly one entity changed.
- `black` clean.