### PR TITLE
Derive ApiValidator interval thresholds from TimeInterval (drop hardcoded 48/16/24)

### DIFF
--- a/custom_components/ge_spot/api/base/api_validator.py
+++ b/custom_components/ge_spot/api/base/api_validator.py
@@ -75,28 +75,30 @@ class ApiValidator:
                 _LOGGER.warning(
                     f"Error calculating DST-aware intervals for {timezone}: {e}, using default"
                 )
-                default_min = 48
+                default_min = TimeInterval.get_intervals_per_day() // 2
         else:
-            default_min = 48
+            default_min = TimeInterval.get_intervals_per_day() // 2
 
         # Use provided min_intervals or calculated default
         effective_min = min_intervals if min_intervals is not None else default_min
 
         # Special handling for sources with different data availability patterns
         if source_name.lower() == Source.AEMO.lower():
-            # For AEMO, we only require at least 16 intervals of data (4 hours with 15-min intervals)
-            # Missing intervals will be filled from fallback sources if available
-            if interval_count < 16:
+            # For AEMO, we only require at least 4 hours of data; missing
+            # intervals are filled from fallback sources if available.
+            aemo_min = TimeInterval.get_intervals_per_hour() * 4
+            if interval_count < aemo_min:
                 _LOGGER.warning(
-                    f"No interval prices from {source_name}: {interval_count}/16"
+                    f"No interval prices from {source_name}: {interval_count}/{aemo_min}"
                 )
                 return False
         elif source_name.lower() == Source.ENTSOE.lower():
-            # For ENTSO-E, we only require at least 24 intervals of data (6 hours with 15-min intervals)
-            # This is because ENTSO-E sometimes only provides partial data
-            if interval_count < 24:
+            # For ENTSO-E, we only require at least 6 hours of data because it
+            # sometimes only provides partial data.
+            entsoe_min = TimeInterval.get_intervals_per_hour() * 6
+            if interval_count < entsoe_min:
                 _LOGGER.warning(
-                    f"Insufficient interval prices from {source_name}: {interval_count}/24"
+                    f"Insufficient interval prices from {source_name}: {interval_count}/{entsoe_min}"
                 )
                 return False
         elif interval_count < effective_min:


### PR DESCRIPTION
## Summary
`ApiValidator.is_data_adequate` hardcoded its minimum-interval thresholds — `default_min = 48`, AEMO `< 16`, ENTSO-E `< 24` — all interval counts implicitly tied to a 96-interval day. This violates the project's config-driven rule (interval counts must come from `TimeInterval`).

### Changes (`api/base/api_validator.py`)
| threshold | before | after | meaning |
|---|---|---|---|
| default minimum | `48` | `get_intervals_per_day() // 2` | half a day |
| AEMO minimum | `16` | `get_intervals_per_hour() * 4` | 4 hours |
| ENTSO-E minimum | `24` | `get_intervals_per_hour() * 6` | 6 hours |

Warning messages now interpolate the computed threshold instead of a literal `/16`, `/24`.

## Testing
- Values verified to evaluate to 48/16/24 for the 15-minute default → **behavior-identical**.
- `python -m pytest tests/pytest/unit/` → **432 passed**; validation/fallback suites pass.
- **Live HA (real instance + debug logging):** SE4 still validates and processes nordpool data (96 intervals), no spurious validation failures.
- `black` clean.