### PR TITLE
Fix Amber end-to-end: no prices, and ~10x-wrong prices once parsed

### DIFF
--- a/custom_components/ge_spot/api/amber.py
+++ b/custom_components/ge_spot/api/amber.py
@@ -103,6 +103,9 @@ class AmberAPI(BasePriceAPI):
                 "interval_raw": interval_raw,
                 "timezone": self.get_timezone_for_area(None),
                 "currency": Currency.AUD,
+                # Parser normalizes Amber's cents/kWh to AUD/kWh; tell the
+                # DataProcessor the unit so it does not divide by 1000 as MWh.
+                "source_unit": "kWh",
                 "source_name": "amber",
                 "raw_data": {
                     "data": data,

--- a/custom_components/ge_spot/api/parsers/amber_parser.py
+++ b/custom_components/ge_spot/api/parsers/amber_parser.py
@@ -42,12 +42,19 @@ class AmberParser(BasePriceParser):
         if isinstance(raw_data, list):
             price_list = raw_data
         elif isinstance(raw_data, dict):
-            # Check common keys where the list might be nested
-            if "data" in raw_data and isinstance(raw_data["data"], list):
-                price_list = raw_data["data"]
-            elif "prices" in raw_data and isinstance(raw_data["prices"], list):
-                price_list = raw_data["prices"]
-            # Add more checks if Amber API structure varies
+            # The Amber API returns a bare list. AmberAPI.fetch_raw_data wraps it
+            # as {"raw_data": {"data": [...]}}, and the DataProcessor re-parses
+            # that wrapper. Look for the list at the top level AND nested one
+            # level deeper under "raw_data" so both inputs yield prices.
+            for candidate in (raw_data, raw_data.get("raw_data")):
+                if not isinstance(candidate, dict):
+                    continue
+                if isinstance(candidate.get("data"), list):
+                    price_list = candidate["data"]
+                    break
+                if isinstance(candidate.get("prices"), list):
+                    price_list = candidate["prices"]
+                    break
 
         if not price_list:
             _LOGGER.warning("No valid price list found in Amber data to parse")

--- a/custom_components/ge_spot/api/parsers/amber_parser.py
+++ b/custom_components/ge_spot/api/parsers/amber_parser.py
@@ -121,9 +121,13 @@ class AmberParser(BasePriceParser):
                     _LOGGER.debug(f"Could not parse Amber price value: {price_cents}")
                     continue
 
-                interval_raw[interval_key] = price  # Store price in Cents/kWh
+                # Amber 'perKwh'/'rrp' are in cents/kWh; normalize to AUD/kWh so
+                # the DataProcessor reads them with currency=AUD and
+                # source_unit=kWh. cents/kWh -> AUD/kWh = / 100.
+                price_aud_kwh = price / 100.0
+                interval_raw[interval_key] = price_aud_kwh
                 _LOGGER.debug(
-                    f"Storing raw Amber price for {interval_key}: {price} Cents/kWh"
+                    f"Storing Amber price for {interval_key}: {price_aud_kwh} AUD/kWh"
                 )
 
             except (ValueError, TypeError, KeyError) as e:
@@ -146,7 +150,7 @@ class AmberParser(BasePriceParser):
                 "currency": Currency.AUD,  # Amber usually uses AUD
                 "timezone": "Australia/Sydney",  # Default Amber timezone
                 "area": "unknown",  # Amber doesn't typically specify area in price data
-                "source_unit": "Cents/kWh",  # Amber 'perKwh' is usually Cents/kWh
+                "source_unit": "kWh",  # prices are normalized to AUD/kWh by the parser
             }
         )
 

--- a/tests/pytest/unit/test_amber_parser.py
+++ b/tests/pytest/unit/test_amber_parser.py
@@ -1,0 +1,47 @@
+"""Tests for the Amber parser, incl. the DataProcessor wrapper-dict path."""
+
+from custom_components.ge_spot.api.parsers.amber_parser import AmberParser
+from custom_components.ge_spot.const.currencies import Currency
+
+SAMPLE = [
+    {"type": "ActualInterval", "startTime": "2026-06-25T00:00:00Z", "perKwh": 25.0},
+    {"type": "ActualInterval", "startTime": "2026-06-25T00:30:00Z", "perKwh": 30.5},
+]
+
+
+def test_parse_raw_list():
+    """Parser extracts prices from the bare API list (the inline parse path)."""
+    result = AmberParser().parse(SAMPLE)
+    assert len(result["interval_raw"]) == 2
+    assert result["currency"] == Currency.AUD
+
+
+def test_parse_direct_data_key():
+    """Parser handles a dict whose 'data' key holds the list."""
+    result = AmberParser().parse({"data": SAMPLE})
+    assert len(result["interval_raw"]) == 2
+
+
+def test_parse_fetch_raw_data_wrapper():
+    """Regression: parser must read the wrapper AmberAPI.fetch_raw_data returns.
+
+    The DataProcessor re-parses that wrapper (``parser.parse(data)``). Before the
+    fix the price list was nested under ``raw_data -> data`` and was never found,
+    so Amber produced zero prices end-to-end.
+    """
+    wrapper = {
+        "interval_raw": {},  # discarded by the DataProcessor, which re-parses
+        "timezone": "Australia/Sydney",
+        "currency": Currency.AUD,
+        "source_name": "amber",
+        "raw_data": {
+            "data": SAMPLE,
+            "timestamp": "2026-06-25T00:00:00+00:00",
+            "area": "12345",
+            "date_range": {"start": "2026-06-24", "end": "2026-06-26"},
+        },
+        "data_source": "amber",
+        "attempted_sources": ["amber"],
+    }
+    result = AmberParser().parse(wrapper)
+    assert len(result["interval_raw"]) == 2, "Amber wrapper dict must yield prices"

--- a/tests/pytest/unit/test_amber_parser.py
+++ b/tests/pytest/unit/test_amber_parser.py
@@ -45,3 +45,21 @@ def test_parse_fetch_raw_data_wrapper():
     }
     result = AmberParser().parse(wrapper)
     assert len(result["interval_raw"]) == 2, "Amber wrapper dict must yield prices"
+
+
+def test_parse_normalizes_perkwh_cents_to_aud_per_kwh():
+    """'perKwh' (cents/kWh) is normalized to AUD/kWh (25 c/kWh -> 0.25 AUD/kWh).
+
+    Without this, the DataProcessor reads the value as AUD/MWh and the final
+    price is ~10x too low.
+    """
+    result = AmberParser().parse(
+        [{"startTime": "2026-06-25T00:00:00Z", "perKwh": 25.0}]
+    )
+    assert list(result["interval_raw"].values()) == [0.25]
+
+
+def test_parse_rrp_fallback_normalizes_to_aud_per_kwh():
+    """'rrp' (AUD/MWh) also normalizes to AUD/kWh (100 AUD/MWh -> 0.10 AUD/kWh)."""
+    result = AmberParser().parse([{"startTime": "2026-06-25T00:00:00Z", "rrp": 100.0}])
+    assert list(result["interval_raw"].values()) == [0.10]

--- a/tests/pytest/unit/test_parser_raw_data_parameter.py
+++ b/tests/pytest/unit/test_parser_raw_data_parameter.py
@@ -622,7 +622,11 @@ class TestEdgeCasesAndErrorHandling:
         assert any(p > 0 for p in prices), "Should preserve positive prices"
 
     def test_very_large_prices_preserved(self, timezone_service):
-        """Test that very large prices (price spikes) are preserved."""
+        """Test that very large prices (price spikes) are preserved.
+
+        Amber 'perKwh' is in cents/kWh and the parser normalizes it to AUD/kWh
+        (/100), so a 15000 c/kWh spike is preserved as 150.0 AUD/kWh.
+        """
         parser = AmberParser(timezone_service=timezone_service)
 
         # Australia occasionally has extreme price spikes
@@ -638,7 +642,7 @@ class TestEdgeCasesAndErrorHandling:
         result = parser.parse(test_data)
 
         prices = list(result["interval_raw"].values())
-        assert max(prices) == 15000.0, "Should preserve extreme price spikes"
+        assert max(prices) == 150.0, "Should preserve extreme price spikes (AUD/kWh)"
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
Amber was **non-functional** end-to-end, found while tracing the Amber data path during a full-codebase audit. Two independent bugs that together meant Amber either returned nothing or wildly wrong prices:

### Bug 1 — Amber returns no prices (wrapper not parsed)
`AmberAPI.fetch_raw_data` returns a wrapper whose price list is nested at `raw_data["data"]`. The `DataProcessor` always **re-parses** fresh data via `parser.parse(data)` with that wrapper, but `AmberParser.parse` only looked for the list at the **top level** (`data`/`prices`), never under `raw_data`. Result: `price_list = None` → 0 intervals → Amber unusable.

**Fix:** `AmberParser.parse` now finds the list at the top level **and** nested under `raw_data`.

### Bug 2 — prices ~10x too low (cents/kWh treated as AUD/MWh)
Amber `perKwh` is in **cents/kWh**, but the parser stored it raw and the wrapper declared **no `source_unit`**, so the `DataProcessor` defaulted to `MWh` and divided by 1000. Net: a 25 c/kWh price (0.25 AUD/kWh) came out as **0.025 AUD/kWh**.

```
convert_energy_price(25, source_unit=MWh)  -> 0.025 AUD/kWh   # before (wrong)
convert_energy_price(0.25, source_unit=kWh) -> 0.25 AUD/kWh   # after (correct)
```

**Fix:** the parser normalizes to **AUD/kWh** (cents/kWh ÷ 100; the `rrp` AUD/MWh fallback ÷ 1000), and `AmberAPI.fetch_raw_data` declares `source_unit="kWh"`.

## Testing
- New `tests/pytest/unit/test_amber_parser.py`: bare list, top-level `data` dict, the `fetch_raw_data` wrapper (regression for bug 1), and magnitude checks (25 c/kWh → 0.25; 100 AUD/MWh → 0.10) for bug 2.
- Updated `test_very_large_prices_preserved` to the corrected unit (15000 c/kWh → 150.0 AUD/kWh).
- `python -m pytest tests/pytest/unit/` → **437 passed**.
- Live HA: integration loads cleanly with the changes; the configured SE4 area (nordpool/energy-charts) is unaffected.
- `black` clean.

Note: a fully-live Amber check needs an Amber API key + Australian site_id (not available in the dev environment); both bugs and fixes are reproduced deterministically via the parser + the real `convert_energy_price` conversion.