### PR TITLE
Run AEMO ZIP decompression off the event loop (HA async compliance)

### DIFF
--- a/custom_components/ge_spot/api/aemo.py
+++ b/custom_components/ge_spot/api/aemo.py
@@ -1,5 +1,6 @@
 """API handler for AEMO (Australian Energy Market Operator) - NEMWEB Pre-dispatch."""
 
+import asyncio
 import logging
 import re
 from datetime import datetime, timezone
@@ -95,9 +96,14 @@ class AemoAPI(BasePriceAPI):
                 _LOGGER.error("Failed to download pre-dispatch file")
                 return None
 
-            # Step 3: Extract CSV from ZIP
+            # Step 3: Extract CSV from ZIP. zipfile decompression + UTF-8 decode
+            # are blocking, so run them in an executor to keep the event loop
+            # responsive (Home Assistant flags blocking calls on the loop).
             _LOGGER.debug(f"Extracting CSV from ZIP ({len(zip_data):,} bytes)")
-            csv_content = unzip_single_file(zip_data, expected_extension=".csv")
+            loop = asyncio.get_running_loop()
+            csv_content = await loop.run_in_executor(
+                None, unzip_single_file, zip_data, ".csv"
+            )
 
             _LOGGER.info(
                 f"Extracted CSV ({len(csv_content):,} characters) for region {area}"


### PR DESCRIPTION
## Summary
`AemoAPI.fetch_raw_data` (an `async` method) called `unzip_single_file(zip_data, ...)` **directly on the event loop**. That helper uses `zipfile` + `.read().decode()`, which are blocking; on the NEMWEB pre-dispatch ZIP this runs synchronous decompression on the loop. Home Assistant flags blocking calls on the event loop (warning + stack trace pointing at the integration since HA 2024.7), and it briefly stalls the loop.

## Fix
Wrap the decompression in `loop.run_in_executor(None, unzip_single_file, zip_data, ".csv")` so it runs in a worker thread. Behavior is otherwise identical.

This matches the integration's existing async-compliance effort (commit `f02904a`, "Avoid blocking I/O on the event loop in cache + API client").

## Testing
- Verified the executor path returns **identical** output to the direct call on a real in-memory ZIP.
- `python -m pytest tests/pytest/unit/` → **432 passed**; AEMO parser tests pass.
- Live HA loads cleanly with the change.
- `black` clean.