### PR TITLE
Sensors use the configured area timezone for interval-time attributes & hourly current-hour

### DIFF
--- a/custom_components/ge_spot/sensor/base.py
+++ b/custom_components/ge_spot/sensor/base.py
@@ -44,8 +44,15 @@ class BaseElectricityPriceSensor(SensorEntity):
         if not isinstance(config_data, dict):
             raise TypeError("config_data must be a dictionary")
 
-        # Store timezone service for EV Smart Charging attribute conversion
-        self._tz_service = getattr(coordinator, "_tz_service", None)
+        # Store timezone service for EV Smart Charging attribute conversion.
+        # The coordinator (a DataUpdateCoordinator) does not hold the timezone
+        # service directly — it lives on its price_manager — so resolve from
+        # either. Without this the service is always None and interval-time
+        # attributes fall back to Home Assistant's default zone instead of the
+        # configured area timezone.
+        self._tz_service = getattr(coordinator, "_tz_service", None) or getattr(
+            getattr(coordinator, "price_manager", None), "_tz_service", None
+        )
 
         self._area = config_data.get(Attributes.AREA)
         self._vat = config_data.get(Attributes.VAT, 0)
@@ -94,6 +101,19 @@ class BaseElectricityPriceSensor(SensorEntity):
             self._attr_native_unit_of_measurement = f"{self._currency}/kWh"
 
         self._attr_suggested_display_precision = self._precision
+
+    @property
+    def _target_timezone(self):
+        """Timezone used for interval-time attributes.
+
+        Interval keys are in the configured area timezone (Local Area Time
+        mode), so datetimes and current-hour lookups must use the same zone.
+        Falls back to Home Assistant's default zone only if the service is
+        unavailable.
+        """
+        if self._tz_service:
+            return self._tz_service.target_timezone
+        return dt_util.get_default_time_zone()
 
     @property
     def available(self):
@@ -221,13 +241,8 @@ class BaseElectricityPriceSensor(SensorEntity):
         # Format: [{"time": datetime object, "value": float}, ...]
         # External integrations (EV Smart Charging) expect this format
 
-        # Get target timezone
-        target_tz = None
-        if self._tz_service:
-            target_tz = self._tz_service.target_timezone
-        else:
-            # Fallback to HA default timezone
-            target_tz = dt_util.get_default_time_zone()
+        # Get target timezone (interval keys are area-local; see _target_timezone)
+        target_tz = self._target_timezone
 
         # Convert today's prices from HH:MM dict to list of datetime objects
         if self.coordinator.data and self.coordinator.data.today_interval_prices:

--- a/custom_components/ge_spot/sensor/price.py
+++ b/custom_components/ge_spot/sensor/price.py
@@ -447,8 +447,9 @@ class HourlyAverageSensor(PriceValueSensor):
 
             # Get current hour (or first hour of tomorrow for tomorrow sensor)
             if self._day_offset == 0:
-                # For today: get current hour
-                now = dt_util.now()
+                # For today: current hour in the area timezone so it matches the
+                # area-local interval keys (HA's zone may differ from the area's).
+                now = dt_util.now().astimezone(self._target_timezone)
                 current_hour = f"{now.hour:02d}:00"
                 return hourly_prices.get(current_hour)
             else:
@@ -538,8 +539,8 @@ class HourlyAverageSensor(PriceValueSensor):
         Returns:
             List of dicts with 'time' (datetime) and 'value' (float) keys
         """
-        # Get target timezone
-        target_tz = dt_util.get_default_time_zone()
+        # Get target timezone (area-local interval keys, see _target_timezone)
+        target_tz = self._target_timezone
 
         hourly_list = []
         for hhmm_key in sorted(hourly_prices.keys()):
@@ -576,8 +577,8 @@ class HourlyAverageSensor(PriceValueSensor):
         if not self.coordinator.data:
             return attrs
 
-        # Get target timezone for datetime conversion
-        target_tz = dt_util.get_default_time_zone()
+        # Get target timezone for datetime conversion (area-local interval keys)
+        target_tz = self._target_timezone
         now = dt_util.now().astimezone(target_tz)
 
         # Calculate hourly averages for today and tomorrow

--- a/tests/pytest/unit/test_hourly_average_sensor.py
+++ b/tests/pytest/unit/test_hourly_average_sensor.py
@@ -182,6 +182,8 @@ class TestHourlyAverageSensor:
             "Hourly Average Price",
             day_offset=0,
         )
+        # Interval keys and the mocked "now" are both in UTC here.
+        sensor._tz_service = Mock(target_timezone=timezone.utc)
 
         # The sensor should return hour 01:00's average
         value = sensor.native_value
@@ -316,6 +318,7 @@ class TestHourlyAverageSensor:
             "Hourly Average Price",
             day_offset=0,
         )
+        sensor._tz_service = Mock(target_timezone=timezone.utc)
 
         value = sensor.native_value
         assert value == 53.0  # Average of 23:00 hour
@@ -341,6 +344,7 @@ class TestHourlyAverageSensor:
             "Hourly Average Price",
             day_offset=0,
         )
+        sensor2._tz_service = Mock(target_timezone=timezone.utc)
 
         value2 = sensor2.native_value
         assert value2 == 13.0  # Average of 00:00 hour
@@ -522,6 +526,7 @@ class TestHourlyAverageSensor:
                 "Hourly Average Price",
                 day_offset=0,
             )
+            sensor._tz_service = Mock(target_timezone=timezone.utc)
 
             # Should return None since current hour has no data
             assert sensor.native_value is None


### PR DESCRIPTION
## Summary
Two related timezone bugs in the sensor layer, sharing one root cause.

### Root cause
`sensor/base.py` resolves the timezone service with `getattr(coordinator, "_tz_service", None)`. But `_tz_service` lives on the coordinator's **`price_manager`**, not on the `DataUpdateCoordinator` itself — so it was **always `None`**, and every sensor fell back to Home Assistant's default zone (`dt_util.get_default_time_zone()`). Interval keys are in the **area** timezone in Local Area Time mode (the default), so the fallback is wrong whenever HA's zone differs from the area's.

### Impact
- **`today/tomorrow_interval_prices` attribute datetimes** were stamped with the wrong UTC offset (HA default instead of the area zone). External consumers like **EV Smart Charging** read these as datetime objects → wrong absolute times.
- **`HourlyAverageSensor`** picked the "current hour" from `dt_util.now()` (HA clock) while the interval keys are area-local → it returned the **wrong hour's average** when the zones differ. (Also its hourly attribute datetimes used `get_default_time_zone()`.)

### Fix
- Resolve `_tz_service` from `coordinator.price_manager` as a fallback.
- Add a shared `_target_timezone` property on the base sensor and use it for the interval-time attributes and in `HourlyAverageSensor` (current-hour selection + hourly attribute datetimes).

## Testing
- `python -m pytest tests/pytest/unit/` → **432 passed**. The 3 hourly-sensor tests that implicitly assumed "now-tz == keys-tz" were updated to set that explicitly (UTC); assertions unchanged.
- **Live HA (HA tz = UTC, area SE4 = Europe/Stockholm):** before, `today_interval_prices` times were `...T00:00:00+00:00`; after, `...T00:00:00+02:00` (correct area-local), and the hourly sensor selects the Stockholm hour.
- `black` clean.