### PR TITLE
Remove dead config-flow code (unused validators + orphaned create_api factory)

### DIFF
--- a/custom_components/ge_spot/api/__init__.py
+++ b/custom_components/ge_spot/api/__init__.py
@@ -1,11 +1,6 @@
 """API module for the GE-Spot integration."""
 
-import logging
-from typing import List, Dict, Any, Optional
-
-from ..const.sources import Source
-
-_LOGGER = logging.getLogger(__name__)
+from typing import List
 
 
 def get_sources_for_region(region: str) -> List[str]:
@@ -13,50 +8,3 @@ def get_sources_for_region(region: str) -> List[str]:
     from ..const.areas import get_available_sources
 
     return get_available_sources(region)
-
-
-def create_api(source_type: str, config: Optional[Dict[str, Any]] = None, session=None):
-    """Create an API instance for the specified source type.
-
-    Args:
-        source_type: Source type identifier
-        config: Optional configuration dictionary
-        session: Optional session for API requests
-
-    Returns:
-        API instance for the specified source type
-    """
-    if source_type == Source.ENTSOE:
-        from .entsoe import EntsoeAPI
-
-        return EntsoeAPI(config, session)
-    elif source_type == Source.NORDPOOL:
-        from .nordpool import NordpoolAPI
-
-        return NordpoolAPI(config, session)
-    elif source_type == Source.ENERGI_DATA_SERVICE:
-        from .energi_data import EnergiDataAPI
-
-        return EnergiDataAPI(config, session)
-    elif source_type == Source.AEMO:
-        from .aemo import AemoAPI
-
-        return AemoAPI(config, session)
-    elif source_type == Source.ENERGY_CHARTS:
-        from .energy_charts import EnergyChartsAPI
-
-        return EnergyChartsAPI(config, session)
-    elif source_type == Source.OMIE:
-        from .omie import OmieAPI
-
-        return OmieAPI(config, session)
-    elif source_type == Source.STROMLIGNING:
-        from .stromligning import StromligningAPI
-
-        return StromligningAPI(config, session)
-    elif source_type == Source.COMED:
-        from .comed import ComedAPI
-
-        return ComedAPI(config, session)
-    else:
-        raise ValueError(f"Unknown source type: {source_type}")

--- a/custom_components/ge_spot/config_flow/implementation.py
+++ b/custom_components/ge_spot/config_flow/implementation.py
@@ -28,7 +28,6 @@ from .schemas import (
     get_api_keys_schema,
     get_stromligning_config_schema,  # Import new schema
     get_user_schema,
-    get_default_values,
 )
 from .options import GSpotOptionsFlow
 
@@ -39,7 +38,6 @@ class GSpotConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for GE-Spot integration."""
 
     VERSION = 1
-    CONNECTION_CLASS = "cloud_poll"
 
     def __init__(self):
         """Initialize the config flow."""

--- a/custom_components/ge_spot/config_flow/validators.py
+++ b/custom_components/ge_spot/config_flow/validators.py
@@ -5,72 +5,8 @@ from typing import Dict, List
 
 from ..const.areas import AreaMapping
 from ..const.sources import Source
-from ..api import create_api
 
 _LOGGER = logging.getLogger(__name__)
-
-
-async def validate_entsoe_api_key(api_key, area, session=None):
-    """Validate an ENTSO-E API key by making a test request."""
-    try:
-        # Create a temporary API instance
-        config = {"area": area, "api_key": api_key}
-        api = create_api(Source.ENTSOE, config)
-
-        # Use provided session if available
-        if session:
-            api.session = session
-            api._owns_session = False
-
-        # Try to fetch some data with the provided key
-        _LOGGER.debug(f"Validating ENTSO-E API key for area {area}")
-        result = await api._fetch_data()
-
-        # Close session if we created one
-        if (
-            hasattr(api, "_owns_session")
-            and api._owns_session
-            and hasattr(api, "close")
-        ):
-            await api.close()
-
-        # Check if we got a valid response
-        if (
-            result
-            and isinstance(result, str)
-            and "<Publication_MarketDocument" in result
-        ):
-            _LOGGER.debug("ENTSO-E API key validation successful")
-            return True
-        elif isinstance(result, str) and "Not authorized" in result:
-            _LOGGER.error("API key validation failed: Not authorized")
-            return False
-        elif isinstance(result, str) and "No matching data found" in result:
-            # This is technically a valid API key, even if there's no data
-            _LOGGER.warning(
-                "API key is valid but no data available for the specified area"
-            )
-            return True
-        else:
-            _LOGGER.error("API key validation failed: No valid data returned")
-            return False
-
-    except Exception as e:
-        _LOGGER.error(f"API key validation error: {e}")
-        return False
-
-
-def get_entso_e_api_key_description(area):
-    """Get description for ENTSO-E API key entry."""
-    is_supported = area in AreaMapping.ENTSOE_MAPPING
-    # Show different message based on whether area is directly supported
-    description = (
-        "Optional API key for ENTSO-E (recommended for better reliability)"
-        if is_supported
-        else "Required API key for ENTSO-E (needed for this region)"
-    )
-
-    return description
 
 
 def validate_area_sources(area: str, available_sources: List[str]) -> Dict[str, str]:
@@ -100,40 +36,3 @@ def validate_area_sources(area: str, available_sources: List[str]) -> Dict[str, 
             )
 
     return errors
-
-
-def validate_source_availability(area: str, source: str) -> bool:
-    """Check if a source is actually available for an area.
-
-    Args:
-        area: Area code
-        source: Source identifier
-
-    Returns:
-        True if source can work for this area
-    """
-    if source == Source.ENTSOE:
-        return area in AreaMapping.ENTSOE_MAPPING
-
-    if source == Source.NORDPOOL:
-        return area in AreaMapping.NORDPOOL_AREAS
-
-    if source == Source.ENERGY_CHARTS:
-        return area in AreaMapping.ENERGY_CHARTS_BZN
-
-    if source == Source.ENERGI_DATA_SERVICE:
-        return area in AreaMapping.ENERGI_DATA_AREAS
-
-    if source == Source.OMIE:
-        return area in AreaMapping.OMIE_AREAS
-
-    if source == Source.AEMO:
-        return area in AreaMapping.AEMO_AREAS
-
-    if source == Source.STROMLIGNING:
-        return area in AreaMapping.STROMLIGNING_AREAS
-
-    if source == Source.COMED:
-        return area in AreaMapping.COMED_AREAS
-
-    return False


### PR DESCRIPTION
## Summary
Dead-code cleanup in the config-flow layer (all verified to have no callers across `custom_components/` and `tests/`):

- **`config_flow/validators.py`** — `validate_entsoe_api_key`, `get_entso_e_api_key_description`, `validate_source_availability` are unused (the flow validates ENTSO-E keys via `entsoe.validate_api_key`). `validate_area_sources` (the one that *is* used) is kept.
- **`api/__init__.py`** — `create_api` was called **only** by the now-removed `validate_entsoe_api_key`, so the whole factory is dead and removed. (This also moots the earlier "create_api missing AMBER" observation — the function no longer exists. `get_sources_for_region` is kept.)
- **`config_flow/implementation.py`** — drop the unused `get_default_values` import and the dead `CONNECTION_CLASS` attribute (Home Assistant removed `ConfigFlow.CONNECTION_CLASS` support years ago).

## Testing
- `python -m pytest tests/pytest/unit/` → **432 passed**.
- **Live HA:** integration loads cleanly; **Add entry** opens the area-selection step (exercises `async_step_user`) and **Configure** opens the options flow — both render correctly.
- `black` clean.