### PR TITLE
Remove dead constants (CONFIG_VERSION, MIN_VALID_INTERVALS, unused area maps)

### DIFF
--- a/custom_components/ge_spot/const/__init__.py
+++ b/custom_components/ge_spot/const/__init__.py
@@ -1,8 +1,7 @@
 """Constants for the GE-Spot integration."""
 
-# Domain and version - these stay as top-level constants as they're foundational identifiers
+# Domain - foundational top-level identifier
 DOMAIN = "ge_spot"
-CONFIG_VERSION = 1
 
 # Import all constant classes
 from .config import Config
@@ -29,7 +28,6 @@ from .api import EntsoE, Nordpool, Omie, Stromligning, ECB, SourceTimezone
 __all__ = [
     # Top-level constants
     "DOMAIN",
-    "CONFIG_VERSION",
     # Classes
     "Config",
     "Defaults",

--- a/custom_components/ge_spot/const/areas.py
+++ b/custom_components/ge_spot/const/areas.py
@@ -134,26 +134,6 @@ class AreaMapping:
         Area.PL: Area.PL,
     }
 
-    # Nordpool region mapping for v2 API
-    # Is this needed?
-    NORDPOOL_REGION_MAPPING = {
-        Area.SE1: "Sweden",
-        Area.SE2: "Sweden",
-        Area.SE3: "Sweden",
-        Area.SE4: "Sweden",
-        Area.FI: "Finland",
-        Area.DK1: "Denmark",
-        Area.DK2: "Denmark",
-        Area.NO1: "Norway",
-        Area.NO2: "Norway",
-        Area.NO3: "Norway",
-        Area.NO4: "Norway",
-        Area.NO5: "Norway",
-        Area.LT: "Lithuania",
-        Area.LV: "Latvia",
-        Area.EE: "Estonia",
-    }
-
     # Nordpool areas display names
     NORDPOOL_AREAS = {
         # Nordic regions
@@ -389,18 +369,6 @@ class AreaMapping:
         "aemo": AEMO_AREAS,
         "stromligning": STROMLIGNING_AREAS,
         "comed": COMED_AREAS,
-    }
-
-    # Default areas for each source
-    DEFAULT_AREAS = {
-        "nordpool": Area.SE4,
-        "energi_data_service": Area.DK1,
-        "entsoe": "10Y1001A1001A47J",  # SE4 EIC Code (updated)
-        "energy_charts": Area.DE_LU,
-        "omie": Area.ES,
-        "aemo": Area.NSW1,
-        "stromligning": Area.DK1,
-        "comed": "5minutefeed",
     }
 
 

--- a/custom_components/ge_spot/const/time.py
+++ b/custom_components/ge_spot/const/time.py
@@ -156,10 +156,6 @@ class PeriodType:
     TOMORROW = "tomorrow"
     OTHER = "other"
 
-    MIN_VALID_INTERVALS = (
-        80  # Minimum intervals required for valid data (80 of 96 = 83%)
-    )
-
 
 class DSTTransitionType:
     """DST transition type constants."""


### PR DESCRIPTION
## Summary
Constants with no references anywhere in `custom_components/` or `tests/`:
- **`const/__init__.py`** — `CONFIG_VERSION` (the config flow hardcodes `VERSION = 1`; also dropped from `__all__`).
- **`const/time.py`** — `PeriodType.MIN_VALID_INTERVALS`.
- **`const/areas.py`** — `AreaMapping.NORDPOOL_REGION_MAPPING` (already carried an `# Is this needed?` comment) and `AreaMapping.DEFAULT_AREAS`.

Actively-used maps (e.g. `NORDPOOL_AREAS`, `ENTSOE_MAPPING`) are untouched.

## Testing
- Grep confirms zero references to each removed symbol.
- `const` imports cleanly; removed symbols gone, kept symbols present.
- `python -m pytest tests/pytest/unit/` → **432 passed**.
- Live HA loads normally.
- `black` clean.