### PR TITLE
Fix ComEd prices being 1000x too low (declare kWh source unit)

### DIFF
--- a/custom_components/ge_spot/api/comed.py
+++ b/custom_components/ge_spot/api/comed.py
@@ -10,6 +10,7 @@ import re
 from .base.api_client import ApiClient
 from ..const.sources import Source
 from ..const.api import ComEd
+from ..const.energy import EnergyUnit
 from ..const.network import Network
 from .parsers.comed_parser import ComedParser
 from ..utils.date_range import generate_date_ranges
@@ -63,6 +64,10 @@ class ComedAPI(BasePriceAPI):
                 "interval_raw": interval_raw,
                 "timezone": metadata.get("timezone", "America/Chicago"),
                 "currency": metadata.get("currency", "cents"),
+                # ComEd reports prices in cents/kWh (already per-kWh). Declare the
+                # source energy unit so the downstream MWh->kWh conversion in
+                # DataProcessor is not applied (which would divide prices by 1000).
+                "source_unit": EnergyUnit.KWH,
                 "source_name": "comed",
                 "raw_data": {
                     "data": raw_data,

--- a/tests/pytest/unit/test_comed_source_unit.py
+++ b/tests/pytest/unit/test_comed_source_unit.py
@@ -1,0 +1,43 @@
+"""Regression test: ComEd must declare its source energy unit as kWh.
+
+ComEd's real-time feed reports prices in cents/kWh (already per-kWh). The
+adapter's ``fetch_raw_data`` result is what ``DataProcessor`` reads to decide
+the source energy unit:
+
+    source_unit = data.get("source_unit", EnergyUnit.MWH)
+
+If ``source_unit`` is missing it defaults to MWh, and the downstream
+MWh->kWh conversion divides every ComEd price by 1000. This test pins the
+contract so the unit declaration cannot silently regress again.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from custom_components.ge_spot.api.comed import ComedAPI
+from custom_components.ge_spot.const.energy import EnergyUnit
+
+
+async def test_comed_fetch_raw_data_declares_kwh_source_unit():
+    """fetch_raw_data must set source_unit=kWh so prices are not /1000."""
+    api = ComedAPI()
+
+    # Stub the parser so the test targets fetch_raw_data's result construction
+    # (the fix site), not parser internals.
+    fake_parser = MagicMock()
+    fake_parser.parse.return_value = {"interval_raw": {"2026-06-26T12:00:00": 2.5}}
+    fake_parser.extract_metadata.return_value = {
+        "timezone": "America/Chicago",
+        "currency": "cents",
+    }
+
+    # _fetch_data is mocked, so the injected session is never actually used;
+    # it only needs to be non-None to satisfy the ApiClient session guard.
+    with patch.object(
+        api, "_fetch_data", AsyncMock(return_value=[{"price": "2.5"}])
+    ), patch.object(api, "get_parser_for_area", return_value=fake_parser):
+        result = await api.fetch_raw_data(area="5minutefeed", session=MagicMock())
+
+    assert result, "fetch_raw_data returned empty result"
+    assert result.get("source_unit") == EnergyUnit.KWH
+    # Sanity: ComEd is reported in cents (per kWh), not MWh.
+    assert result.get("currency") == "cents"


### PR DESCRIPTION
## Problem
ComEd price sensors (areas `5minutefeed` / `currenthouraverage`) report values **1000x too low**. The ComEd real-time feed publishes prices in **cents/kWh** (already per-kWh), but `ComedAPI.fetch_raw_data()` did not include a `source_unit` key in its result dict.

`DataProcessor` decides the source energy unit from that dict:
```python
source_unit = data.get("source_unit", EnergyUnit.MWH)  # coordinator/data_processor.py
```
The missing key defaulted to **MWh**, so the MWh→kWh step in `utils/unit_conversion.py` divided every ComEd price by 1000. Current/next/average/peak were all affected, silently (no error).

## Root cause
Every other price source declares its unit (Nordpool/AEMO/EnergyCharts/EnergiData use `MWh`; **Amber and Stromligning use `kWh`** for the identical cents/kWh case). ComEd simply omitted it.

## Fix
Declare `source_unit = EnergyUnit.KWH` in `ComedAPI.fetch_raw_data()` (the dict `DataProcessor` actually reads), mirroring Amber/Stromligning. One ComEd return path serves both ComEd areas.

## Testing
- New regression test `tests/pytest/unit/test_comed_source_unit.py` pins `source_unit == kWh` on the adapter contract — passes.
- `black` clean; import sanity verified.
- Behavior: with the unit declared, the MWh→kWh /1000 conversion no longer applies, so ComEd prices keep their true cents/kWh magnitude.