### PR TITLE
Fix NO1 ENTSO-E mapping returning NO5 (Bergen) prices

### DIFF
--- a/custom_components/ge_spot/const/areas.py
+++ b/custom_components/ge_spot/const/areas.py
@@ -194,7 +194,7 @@ class AreaMapping:
         Area.LV: "10YLV-1001A00074",  # Fixed: added missing zero
         Area.LT: "10YLT-1001A0008Q",  # Fixed: corrected EIC code
         Area.NL: "10YNL----------L",
-        Area.NO1: "10Y1001A1001A48H",  # Updated EIC code (was: 10Y1001A1001A840)
+        Area.NO1: "10YNO-1--------2",  # East Norway (Oslo) — distinct zone from NO5
         Area.NO2: "10YNO-2--------T",  # Updated EIC code (was: 10Y1001A1001A85Y)
         Area.NO3: "10YNO-3--------J",  # Updated EIC code (was: 10Y1001A1001A86W)
         Area.NO4: "10YNO-4--------9",  # Updated EIC code (was: 10Y1001A1001A87U)

--- a/tests/pytest/unit/test_entsoe_areas.py
+++ b/tests/pytest/unit/test_entsoe_areas.py
@@ -70,6 +70,18 @@ class TestEntsoeAreasValidation:
                 area in AreaMapping.ENTSOE_AREAS
             ), f"Newly enabled area '{area}' not visible in ENTSOE_AREAS"
 
+    def test_no1_no5_distinct_eic(self):
+        """NO1 (Oslo) and NO5 (Bergen) are distinct bidding zones with distinct EICs.
+
+        Regression: NO1 was previously mapped to NO5's EIC (10Y1001A1001A48H),
+        so NO1 users received NO5/Bergen prices from ENTSO-E.
+        """
+        assert AreaMapping.ENTSOE_MAPPING["NO1"] == "10YNO-1--------2"
+        assert AreaMapping.ENTSOE_MAPPING["NO5"] == "10Y1001A1001A48H"
+        assert (
+            AreaMapping.ENTSOE_MAPPING["NO1"] != AreaMapping.ENTSOE_MAPPING["NO5"]
+        ), "NO1 and NO5 must not share an EIC code"
+
     def test_non_working_areas_hidden(self):
         """Test that areas with no data are hidden from ENTSOE_AREAS but kept in ENTSOE_MAPPING."""
         non_working = {
@@ -115,10 +127,6 @@ class TestEntsoeAreasValidation:
                 "GB",
                 "IE(SEM)",
             ],  # Great Britain and Ireland SEM share code
-            "10Y1001A1001A48H": [
-                "NO1",
-                "NO5",
-            ],  # NO1 and NO5 might share (verify this is intentional)
             # Note: DE-LU is the only area for the Germany-Luxembourg bidding zone now
             # (DE was removed as it's the same bidding zone)
         }


### PR DESCRIPTION
## Problem
Users who select **NO1 (East Norway / Oslo)** with ENTSO-E as the active/fallback source receive **NO5 (West Norway / Bergen)** prices.

## Root cause
`AreaMapping.ENTSOE_MAPPING` mapped `Area.NO1` to `10Y1001A1001A48H` — which is **NO5's** EIC code:
```python
Area.NO1: "10Y1001A1001A48H",  # (was: 10Y1001A1001A840)
...
Area.NO5: "10Y1001A1001A48H",
```
`api/entsoe.py` sends that EIC straight to the day-ahead query (`in_Domain`/`out_Domain`), so NO1 returns NO5 data. NO2/NO3/NO4 correctly use `10YNO-2--------T` / `-3-` / `-4-`; NO1 should follow the same scheme.

## Verification (live ENTSO-E API)
| EIC | First price 2026-06-26 |
|---|---|
| `10YNO-1--------2` (proposed NO1) | 80.01 |
| `10Y1001A1001A48H` (current = NO5) | 61.27 |

Distinct series → NO1 and NO5 are genuinely different zones, and the current mapping was wrong.

## Fix
- Set `Area.NO1` to its correct EIC `10YNO-1--------2`.
- Remove the NO1/NO5 entry from the test's `allowed_duplicates` (the comment already flagged it as unverified).
- Add a regression test asserting NO1/NO5 have distinct, correct EICs.

## Testing
`pytest tests/pytest/unit/test_entsoe_areas.py` → 12 passed (incl. new regression + now-stricter no-duplicate check). `black` clean.