### PR TITLE
Fix ENTSO-E rejecting mixed-case area codes (Italian zones)

### DIFF
--- a/custom_components/ge_spot/api/entsoe.py
+++ b/custom_components/ge_spot/api/entsoe.py
@@ -112,8 +112,20 @@ class EntsoeAPI(BasePriceAPI):
             )
             raise ValueError(f"No API key provided for {self.source_type}")
 
-        # Map area code to ENTSO-E area code
-        entsoe_area = AreaMapping.ENTSOE_MAPPING.get(area.upper())
+        # Map area code to ENTSO-E area code. Area codes are canonical and some
+        # keys are mixed-case (e.g. "IT-North", "IT-Centre-South"), so do NOT
+        # upper-case the lookup or those zones would never match. Fall back to a
+        # case-insensitive match to tolerate any case-variant input.
+        entsoe_area = AreaMapping.ENTSOE_MAPPING.get(area)
+        if not entsoe_area:
+            entsoe_area = next(
+                (
+                    eic
+                    for code, eic in AreaMapping.ENTSOE_MAPPING.items()
+                    if code.upper() == area.upper()
+                ),
+                None,
+            )
         if not entsoe_area:
             raise ValueError(f"Area '{area}' not supported for ENTSO-E")
 

--- a/tests/pytest/unit/test_entsoe_mixedcase_area.py
+++ b/tests/pytest/unit/test_entsoe_mixedcase_area.py
@@ -1,0 +1,48 @@
+"""Regression test: ENTSO-E must resolve mixed-case area codes.
+
+ENTSOE_MAPPING contains mixed-case keys for the Italian bidding zones
+("IT-North", "IT-Centre-South", ...). The client previously looked them up
+with ``ENTSOE_MAPPING.get(area.upper())``, so e.g. "IT-North".upper() ==
+"IT-NORTH" never matched and those areas raised "not supported for ENTSO-E",
+even though their EIC codes are present. This pins the resolution.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.ge_spot.api.entsoe import EntsoeAPI
+
+
+@pytest.mark.parametrize(
+    "area,expected_eic",
+    [
+        ("IT-North", "10Y1001A1001A71M"),
+        ("IT-Centre-South", "10Y1001A1001A788"),
+        ("IT-South", "10Y1001A1001A885"),
+        ("IT-Sardinia", "10Y1001A1001A73I"),
+        ("IT-Sicily", "10Y1001A1001A74G"),
+        ("it-north", "10Y1001A1001A71M"),  # case-variant input still resolves
+        ("GB", "10Y1001A1001A59C"),  # all-upper key keeps working
+    ],
+)
+async def test_entsoe_resolves_mixed_case_area(area, expected_eic):
+    """_fetch_data must map the area to its EIC and never reject mixed-case zones."""
+    api = EntsoeAPI(config={"api_key": "dummy"})
+    client = AsyncMock()
+    client.fetch = AsyncMock(
+        return_value="<Publication_MarketDocument></Publication_MarketDocument>"
+    )
+    ref = datetime(2026, 6, 26, 12, 0, tzinfo=timezone.utc)
+
+    try:
+        await api._fetch_data(client, area, ref)
+    except ValueError as e:  # pragma: no cover - must not be the "not supported" path
+        assert "not supported" not in str(e), f"area {area!r} wrongly rejected: {e}"
+
+    assert client.fetch.await_count > 0, "no ENTSO-E request was issued"
+    for call in client.fetch.await_args_list:
+        params = call.kwargs.get("params", {})
+        assert params.get("in_Domain") == expected_eic
+        assert params.get("out_Domain") == expected_eic


### PR DESCRIPTION
## Problem
Configuring any Italian ENTSO-E sub-zone (**IT-North, IT-Centre-South, IT-South, IT-South-2, IT-Sardinia, IT-Sicily**) produces a recurring error on every fetch:
```
[IT-North] All sources failed... Last error: Area 'IT-North' not supported for ENTSO-E
```
even though these zones have valid EIC codes in `ENTSOE_MAPPING`. (Found while activating all regions against a live HA.)

## Root cause
`api/entsoe.py` resolved the area with:
```python
entsoe_area = AreaMapping.ENTSOE_MAPPING.get(area.upper())
```
The IT keys are **mixed-case** (`"IT-North"`), so `"IT-North".upper()` → `"IT-NORTH"` never matches → "not supported". All-upper keys (country codes like `GB`, `SE4`, `DE-LU`) happened to work, which is why this went unnoticed.

## Fix
Look up the canonical area code directly, with a case-insensitive fallback for robustness against case-variant input. No other call site uses `.upper()` for this mapping.

## Testing
New `tests/pytest/unit/test_entsoe_mixedcase_area.py` mocks the HTTP client and asserts the resolved `in_Domain`/`out_Domain` EIC for the IT zones, a lowercase variant, and an unchanged all-upper key (GB) — **7 passed**. `black` clean.