### PR TITLE
Stop config flow user step from masking AbortFlow as 'unknown'

### DIFF
--- a/custom_components/ge_spot/config_flow/implementation.py
+++ b/custom_components/ge_spot/config_flow/implementation.py
@@ -5,7 +5,7 @@ import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow
 from homeassistant.core import callback
-from homeassistant.data_entry_flow import FlowResult
+from homeassistant.data_entry_flow import AbortFlow, FlowResult
 
 from ..const import DOMAIN
 from ..const.config import Config
@@ -96,6 +96,11 @@ class GSpotConfigFlow(ConfigFlow, domain=DOMAIN):
                 # Proceed to source priority step
                 return await self.async_step_source_priority()
 
+            except AbortFlow:
+                # Expected flow control (already_configured / already_in_progress
+                # from async_set_unique_id / _abort_if_unique_id_configured).
+                # Let Home Assistant handle it instead of masking it as "unknown".
+                raise
             except Exception as e:
                 _LOGGER.error(f"Unexpected error in async_step_user: {e}")
                 self._errors["base"] = "unknown"

--- a/tests/pytest/unit/test_config_flow_abortflow.py
+++ b/tests/pytest/unit/test_config_flow_abortflow.py
@@ -1,0 +1,43 @@
+"""Regression test: the user step must not swallow Home Assistant's AbortFlow.
+
+``async_step_user`` wrapped its body in a broad ``except Exception`` that also
+caught ``AbortFlow`` — the control-flow exception raised by
+``async_set_unique_id(raise_on_progress=True)`` ("already_in_progress") and
+``_abort_if_unique_id_configured()`` ("already_configured"). That turned both
+into a generic ``base: "unknown"`` form error, so a user re-adding a configured
+region saw "unknown error" instead of the correct abort message.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.data_entry_flow import AbortFlow
+
+from custom_components.ge_spot.config_flow.implementation import GSpotConfigFlow
+from custom_components.ge_spot.const.config import Config
+
+
+async def test_async_step_user_propagates_already_in_progress():
+    """AbortFlow from async_set_unique_id must propagate, not become 'unknown'."""
+    flow = GSpotConfigFlow()
+    with patch.object(
+        flow,
+        "async_set_unique_id",
+        AsyncMock(side_effect=AbortFlow("already_in_progress")),
+    ):
+        with pytest.raises(AbortFlow) as exc:
+            await flow.async_step_user({Config.AREA: "SE4"})
+    assert exc.value.reason == "already_in_progress"
+
+
+async def test_async_step_user_propagates_already_configured():
+    """AbortFlow from _abort_if_unique_id_configured must propagate."""
+    flow = GSpotConfigFlow()
+    with patch.object(flow, "async_set_unique_id", AsyncMock()), patch.object(
+        flow,
+        "_abort_if_unique_id_configured",
+        MagicMock(side_effect=AbortFlow("already_configured")),
+    ):
+        with pytest.raises(AbortFlow) as exc:
+            await flow.async_step_user({Config.AREA: "SE4"})
+    assert exc.value.reason == "already_configured"


### PR DESCRIPTION
## Problem
Re-adding an already-configured region (or starting a duplicate flow while one is in progress) shows a generic **"unknown error"** in the config flow instead of Home Assistant's correct "already configured" / "already in progress" message. (Observed live: adding the same region twice logged `Unexpected error in async_step_user: Flow aborted: already_in_progress`.)

## Root cause
`async_step_user` wraps its body in a broad `except Exception`:
```python
await self.async_set_unique_id(f"gespot_{area}")   # raises AbortFlow(already_in_progress)
self._abort_if_unique_id_configured()              # raises AbortFlow(already_configured)
...
except Exception as e:
    self._errors["base"] = "unknown"
```
`AbortFlow` is HA's control-flow signal, not an error — but the generic handler catches it and rewrites it to `base: "unknown"`, masking the real reason.

## Fix
Re-raise `AbortFlow` before the generic `except Exception` so HA handles expected aborts normally. (The genuine-error path is unchanged.)

## Testing
New `tests/pytest/unit/test_config_flow_abortflow.py` asserts both abort reasons (`already_in_progress`, `already_configured`) propagate as `AbortFlow` instead of becoming `base='unknown'` — **2 passed**. `black` clean.