### PR TITLE
Log handled HTTP 429 rate-limiting as warning/debug, not error

### DIFF
--- a/custom_components/ge_spot/api/base/api_client.py
+++ b/custom_components/ge_spot/api/base/api_client.py
@@ -151,9 +151,20 @@ class ApiClient:
                         # Track consecutive errors for rate limit detection
                         self._track_error_response(url, response.status)
 
-                        _LOGGER.error(
-                            f"API request failed with status {response.status}: {url}"
-                        )
+                        if response.status == 429:
+                            # Rate limiting is expected and handled by the
+                            # retry/fallback path; _track_error_response already
+                            # surfaces it once at WARNING. Log the per-request
+                            # detail at DEBUG so a rate-limited source shared by
+                            # many areas does not flood the log with ERRORs.
+                            _LOGGER.debug(
+                                f"Rate limited (HTTP 429), will fall back / "
+                                f"retry later: {url}"
+                            )
+                        else:
+                            _LOGGER.error(
+                                f"API request failed with status {response.status}: {url}"
+                            )
 
                         # Try to get more detailed error information
                         try:

--- a/custom_components/ge_spot/api/energy_charts.py
+++ b/custom_components/ge_spot/api/energy_charts.py
@@ -152,9 +152,18 @@ class EnergyChartsAPI(BasePriceAPI):
             # Check for error response from API client first
             if isinstance(response, dict) and response.get("error"):
                 error_msg = response.get("message", "Unknown error")
-                _LOGGER.error(
-                    f"Energy-Charts API request failed for {area}: {error_msg}"
-                )
+                if response.get("status_code") == 429:
+                    # Rate limiting is expected and handled by the fallback
+                    # manager; don't log it at ERROR (Energy-Charts' public API
+                    # is strict, so many areas sharing it would flood the log).
+                    _LOGGER.warning(
+                        f"Energy-Charts rate limited for {area}; "
+                        f"will fall back / retry: {error_msg}"
+                    )
+                else:
+                    _LOGGER.error(
+                        f"Energy-Charts API request failed for {area}: {error_msg}"
+                    )
                 return None
 
             # Check for valid response structure

--- a/tests/pytest/unit/test_api_client_rate_limit.py
+++ b/tests/pytest/unit/test_api_client_rate_limit.py
@@ -1,0 +1,73 @@
+"""Regression tests: ApiClient must not log handled HTTP 429 at ERROR level.
+
+A 429 (rate limit) is expected and handled by the retry/fallback path, and
+``_track_error_response`` already surfaces it once at WARNING. The per-request
+detail should be DEBUG so a rate-limited source shared by many areas does not
+flood the log with ERRORs. Other non-200 statuses (e.g. 500) stay ERROR.
+"""
+
+import logging
+
+from custom_components.ge_spot.api.base.api_client import ApiClient
+
+
+class _FakeResponse:
+    """Minimal async-context-manager stand-in for an aiohttp response."""
+
+    def __init__(self, status, body="", content_type="application/json"):
+        self.status = status
+        self._body = body
+        self.headers = {"Content-Type": content_type}
+
+    async def text(self, encoding=None):
+        return self._body
+
+    async def json(self):
+        import json
+
+        return json.loads(self._body or "{}")
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeSession:
+    def __init__(self, response):
+        self._response = response
+
+    def get(self, *args, **kwargs):
+        # aiohttp's session.get(...) is used as an async context manager and is
+        # not awaited, so return the context manager directly.
+        return self._response
+
+
+async def test_429_not_logged_as_error(caplog):
+    """A 429 response returns the error dict but logs no ERROR record."""
+    client = ApiClient(session=_FakeSession(_FakeResponse(429, body="rate limited")))
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG):
+        result = await client.fetch("https://api.energy-charts.info/price")
+
+    assert result.get("error") is True
+    assert result.get("status_code") == 429
+    errors = [r.message for r in caplog.records if r.levelname == "ERROR"]
+    assert errors == [], f"429 must not log ERROR, got: {errors}"
+
+
+async def test_500_still_logged_as_error(caplog):
+    """A genuine server error (500) must still be logged at ERROR."""
+    client = ApiClient(session=_FakeSession(_FakeResponse(500, body="boom")))
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG):
+        result = await client.fetch("https://example.test/x")
+
+    assert result.get("status_code") == 500
+    errors = [r.message for r in caplog.records if r.levelname == "ERROR"]
+    assert any(
+        "status 500" in m for m in errors
+    ), f"500 should log ERROR, got: {errors}"

--- a/tests/pytest/unit/test_energy_charts_api_error_handling.py
+++ b/tests/pytest/unit/test_energy_charts_api_error_handling.py
@@ -235,6 +235,39 @@ class TestEnergyChartsErrorHandling:
         assert len(error_messages) == 0, "Should have no errors for successful response"
 
     @pytest.mark.asyncio
+    async def test_rate_limit_429_logged_as_warning_not_error(self, api, caplog):
+        """A 429 (rate limit) response is handled by fallback and must not log ERROR.
+
+        Energy-Charts' public API is strict; when many configured areas share it
+        the per-request 429 must not flood the log at ERROR level.
+        """
+        mock_client = AsyncMock()
+        mock_client.fetch = AsyncMock(
+            return_value={
+                "error": True,
+                "status_code": 429,
+                "message": "Too Many Requests",
+                "url": "https://api.energy-charts.info/price",
+            }
+        )
+
+        caplog.clear()
+        with caplog.at_level(logging.DEBUG):
+            result = await api._fetch_data(
+                client=mock_client,
+                area="NO2NSL",
+                reference_time=datetime.now(timezone.utc),
+            )
+
+        assert result is None
+        error_messages = [r.message for r in caplog.records if r.levelname == "ERROR"]
+        assert error_messages == [], f"429 must not log ERROR, got: {error_messages}"
+        warnings = [r.message for r in caplog.records if r.levelname == "WARNING"]
+        assert any(
+            "rate limited" in m.lower() for m in warnings
+        ), f"Expected a rate-limit WARNING, got: {warnings}"
+
+    @pytest.mark.asyncio
     async def test_error_check_order(self, api, caplog):
         """Test that error checking happens in correct order.
 


### PR DESCRIPTION
## Problem
When many configured areas share a rate-limited public API — notably **Energy-Charts**, which allows only ~2 requests per several seconds — the setup/daily health check validates the source for every area at once and trips **HTTP 429**. Each 429 was logged at **ERROR twice** (once in `ApiClient.fetch()`, once in the Energy-Charts adapter), flooding the log even though the condition is **expected and fully handled** by the retry/fallback path. (This was the main remaining source of log errors after activating all 52 regions.)

## Fix (log level only — no behaviour change)
- `ApiClient.fetch()`: a **429** is logged at **DEBUG** (it still returns the same error dict, and `_track_error_response()` already surfaces it once at WARNING). All other non-200 statuses keep logging at **ERROR**.
- Energy-Charts adapter: a rate-limited (`status_code == 429`) error response is logged at **WARNING** instead of ERROR.

Control flow is unchanged — the fallback manager still records a single ERROR only when *all* sources for an area genuinely fail.

## Testing
- New `tests/pytest/unit/test_api_client_rate_limit.py`: a 429 logs **no ERROR**; a 500 **still** logs ERROR.
- New case in `test_energy_charts_api_error_handling.py`: a 429 logs **WARNING, not ERROR** (existing exact-count error tests stay green by keying on `status_code == 429`).
- Full unit suite: **451 passed**.
- **Live-verified**: forced a real Energy-Charts outage (curl: 260/266 → 429), then made HA re-validate energy_charts for NO2NSL + others during that window. HA logged **87 DEBUG** (`Rate limited (HTTP 429)…`) + **174 WARNING** and **0 ERROR** from the per-request paths.

## Out of scope (follow-up)
Under a *total* energy_charts outage the **health-check's per-source validation** still surfaces `fallback_manager: All sources failed… Attempted: energy_charts` at ERROR. That lives in the coordinator/health-check layer (broader blast radius) and is left for a separate, considered change.