### PR TITLE
Remove dead code in config_flow (unused imports + dead variable)

### DIFF
--- a/custom_components/ge_spot/config_flow/implementation.py
+++ b/custom_components/ge_spot/config_flow/implementation.py
@@ -15,7 +15,6 @@ from ..const.defaults import Defaults
 from ..const.areas import AreaMapping
 from ..api import get_sources_for_region
 from ..api import entsoe
-from ..utils.exchange_service import get_exchange_service
 
 from .utils import (
     get_deduplicated_regions,
@@ -290,7 +289,7 @@ class GSpotConfigFlow(ConfigFlow, domain=DOMAIN):
     def _get_region_name(self, region_code):
         """Get display name for a region code."""
         region_name = None
-        for source, area_dict in AreaMapping.ALL_AREAS.items():
+        for area_dict in AreaMapping.ALL_AREAS.values():
             if region_code in area_dict:
                 region_name = area_dict[region_code]
                 break

--- a/custom_components/ge_spot/config_flow/options.py
+++ b/custom_components/ge_spot/config_flow/options.py
@@ -126,14 +126,12 @@ class GSpotOptionsFlow(OptionsFlow):
                 # Handle source priority, timezone reference, and Stromlinging supplier updates if present
                 # ALWAYS update entry.data to ensure API key and other data fields are persisted
                 updated_data = dict(self._data)
-                data_changed = False
 
                 if Config.SOURCE_PRIORITY in user_input:
                     updated_data[Config.SOURCE_PRIORITY] = user_input[
                         Config.SOURCE_PRIORITY
                     ]
                     user_input.pop(Config.SOURCE_PRIORITY)
-                    data_changed = True
 
                 if Config.TIMEZONE_REFERENCE in user_input:
                     _LOGGER.debug(
@@ -143,7 +141,6 @@ class GSpotOptionsFlow(OptionsFlow):
                         Config.TIMEZONE_REFERENCE
                     ]
                     # Keep in options as well
-                    data_changed = True
 
                 # Handle Stromligning supplier update
                 if Config.CONF_STROMLIGNING_SUPPLIER in user_input:
@@ -152,7 +149,6 @@ class GSpotOptionsFlow(OptionsFlow):
                     updated_data[Config.CONF_STROMLIGNING_SUPPLIER] = supplier_value
                     # Remove from options dict before saving options
                     user_input.pop(Config.CONF_STROMLIGNING_SUPPLIER)
-                    data_changed = True
 
                 # Update the config entry data (this includes the API key from self._data)
                 entry = self.hass.config_entries.async_get_entry(self.entry_id)

--- a/custom_components/ge_spot/config_flow/schemas.py
+++ b/custom_components/ge_spot/config_flow/schemas.py
@@ -1,7 +1,6 @@
 """Form schemas for config flow."""
 
 import logging
-from typing import Dict, Any
 import voluptuous as vol
 
 from homeassistant.helpers import selector
@@ -10,10 +9,9 @@ from ..const.areas import AreaMapping
 from ..const.config import Config
 from ..const.defaults import Defaults
 from ..const.sources import Source
-from ..const.display import DisplayUnit, UpdateInterval
+from ..const.display import DisplayUnit
 from ..const.time import TimezoneReference
 from ..utils.form_helper import FormHelper
-from ..api import get_sources_for_region
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/ge_spot/config_flow/utils.py
+++ b/custom_components/ge_spot/config_flow/utils.py
@@ -61,7 +61,7 @@ def get_deduplicated_regions():
         # Sort by source priority (lower number = higher priority)
         sorted_variants = sorted(name_variants)
         # Choose the preferred region code based on source priority
-        for priority, region_code, display_name, source in sorted_variants:
+        for _priority, region_code, display_name, _source in sorted_variants:
             try:
                 # Only include if the region is supported by at least one API
                 supported_sources = get_sources_for_region(region_code)


### PR DESCRIPTION
## Summary
Removes pylint-flagged dead code in the config flow (no behaviour change), matching the project's prior per-area dead-code cleanups (e.g. #84).

- **schemas.py**: drop unused imports `Dict`, `Any` (typing), `UpdateInterval` (const.display), `get_sources_for_region` (api).
- **implementation.py**: drop unused import `get_exchange_service`; iterate `ALL_AREAS.values()` in `_get_region_name` since the dict key was unused.
- **options.py**: remove the write-only `data_changed` flag — `async_update_entry` runs unconditionally, so it was never read.
- **utils.py**: mark the unused tuple-unpack vars in `get_deduplicated_regions` as dummies (`_priority`, `_source`).

## Verification
- Each symbol confirmed unreferenced (grep + pylint `unused-import`/`unused-variable`, now clean for config_flow).
- `black` clean; config_flow modules import cleanly under the HA venv.
- Full unit suite: **451 passed** (incl. config-flow + options-flow regression tests).
- Pure dead-code removal in the config-flow UI handlers — no runtime/setup path touched.