### PR TITLE
Remove dead code: unused import + unnecessary pass statements

### DIFF
--- a/custom_components/ge_spot/api/base/base_price_api.py
+++ b/custom_components/ge_spot/api/base/base_price_api.py
@@ -59,7 +59,6 @@ class BasePriceAPI(ABC):
         Returns:
             Base URL as string
         """
-        pass
 
     @abstractmethod
     async def fetch_raw_data(
@@ -75,7 +74,6 @@ class BasePriceAPI(ABC):
         Returns:
             List of standardized price data dictionaries
         """
-        pass
 
     async def parse_raw_data(self, raw_data: Any) -> Dict[str, Any]:
         """Default parse_raw_data implementation (not used in new adapters)."""

--- a/custom_components/ge_spot/api/base/price_parser.py
+++ b/custom_components/ge_spot/api/base/price_parser.py
@@ -35,7 +35,6 @@ class BasePriceParser(ABC):
         Returns:
             Dict with parsed data
         """
-        pass
 
     def extract_metadata(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """Extract metadata from parsed data.

--- a/custom_components/ge_spot/sensor/base.py
+++ b/custom_components/ge_spot/sensor/base.py
@@ -15,7 +15,6 @@ from ..const.currencies import CurrencyInfo
 from ..const.defaults import Defaults
 from ..const.display import DisplayUnit
 from ..coordinator.data_processor import parse_interval_key
-from ..coordinator.data_validity import DataValidity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/ge_spot/sensor/price.py
+++ b/custom_components/ge_spot/sensor/price.py
@@ -189,13 +189,9 @@ class TomorrowSensorMixin:
 class TomorrowExtremaPriceSensor(TomorrowSensorMixin, ExtremaPriceSensor):
     """Extrema price sensor for tomorrow data with proper availability behavior."""
 
-    pass
-
 
 class TomorrowAveragePriceSensor(TomorrowSensorMixin, PriceValueSensor):
     """Average price sensor for tomorrow data with proper availability behavior."""
-
-    pass
 
 
 class PriceStatisticSensor(PriceValueSensor):
@@ -668,5 +664,3 @@ class HourlyAverageSensor(PriceValueSensor):
 
 class TomorrowHourlyAverageSensor(TomorrowSensorMixin, HourlyAverageSensor):
     """Hourly average price sensor for tomorrow with proper availability."""
-
-    pass


### PR DESCRIPTION
## Summary
Small dead-code cleanup (no behaviour change), continuing the project's per-area dead-code removals (#84, #92).

- **sensor/base.py**: drop unused import `DataValidity` (never referenced).
- **api/base/base_price_api.py**, **api/base/price_parser.py**: drop the `pass` after the docstring in abstract methods — the docstring is a valid body and `@abstractmethod` already prevents instantiation.
- **sensor/price.py**: drop the `pass` in three empty `Tomorrow*` sensor subclasses that only carry a docstring.

## Verification
- Each item confirmed safe (grep + pylint `unused-import`/`unnecessary-pass`, now clean for these files). `nordpool_parser`'s `timezone` import was a pylint false positive (it IS used) and is intentionally left untouched.
- `black` clean; touched modules import cleanly under the HA venv.
- Full unit suite: **451 passed**.