### PR TITLE
Apply price-affecting option changes without an HA restart

### DIFF
--- a/custom_components/ge_spot/coordinator/data_models.py
+++ b/custom_components/ge_spot/coordinator/data_models.py
@@ -83,6 +83,16 @@ class IntervalPriceData:
     vat_included: bool = False
     display_unit: str = "EUR/kWh"
 
+    # Price-affecting config actually applied when these prices were computed.
+    # Lets fetch_data detect an option change and reprocess instead of serving a
+    # stale, fully-baked cache (otherwise VAT/multiplier/tariff/tax edits would
+    # only take effect after an HA restart).
+    applied_vat_rate: float = 0.0
+    applied_include_vat: bool = False
+    applied_import_multiplier: float = 1.0
+    applied_additional_tariff: float = 0.0
+    applied_energy_tax: float = 0.0
+
     # Timestamps
     fetched_at: Optional[str] = None
     last_updated: Optional[str] = None
@@ -549,6 +559,12 @@ class IntervalPriceData:
             "vat_rate": self.vat_rate,
             "vat_included": self.vat_included,
             "display_unit": self.display_unit,
+            # Applied price-affecting config (for cache invalidation on change)
+            "applied_vat_rate": self.applied_vat_rate,
+            "applied_include_vat": self.applied_include_vat,
+            "applied_import_multiplier": self.applied_import_multiplier,
+            "applied_additional_tariff": self.applied_additional_tariff,
+            "applied_energy_tax": self.applied_energy_tax,
             # Timestamps
             "fetched_at": self.fetched_at,
             "last_updated": self.last_updated,
@@ -612,6 +628,12 @@ class IntervalPriceData:
             vat_rate=data.get("vat_rate", 0.0),
             vat_included=data.get("vat_included", False),
             display_unit=data.get("display_unit", "EUR/kWh"),
+            # Applied price-affecting config (for cache invalidation on change)
+            applied_vat_rate=data.get("applied_vat_rate", 0.0),
+            applied_include_vat=data.get("applied_include_vat", False),
+            applied_import_multiplier=data.get("applied_import_multiplier", 1.0),
+            applied_additional_tariff=data.get("applied_additional_tariff", 0.0),
+            applied_energy_tax=data.get("applied_energy_tax", 0.0),
             # Timestamps
             fetched_at=data.get("fetched_at"),
             last_updated=data.get("last_updated"),

--- a/custom_components/ge_spot/coordinator/data_processor.py
+++ b/custom_components/ge_spot/coordinator/data_processor.py
@@ -430,6 +430,13 @@ class DataProcessor:
             "vat_rate": self.vat_rate * 100 if self.include_vat else 0,
             "vat_included": self.include_vat,
             "display_unit": self.display_unit,
+            # Stamp the exact price-affecting config applied, so the coordinator can
+            # detect option changes and reprocess instead of serving stale cache.
+            "applied_vat_rate": self.vat_rate,
+            "applied_include_vat": self.include_vat,
+            "applied_import_multiplier": self.import_multiplier,
+            "applied_additional_tariff": self.additional_tariff,
+            "applied_energy_tax": self.energy_tax,
             "raw_data": raw_api_data_for_result,  # Store original raw API data (XML, JSON, etc.)
             "ecb_rate": ecb_rate,
             "ecb_updated": ecb_updated,

--- a/custom_components/ge_spot/coordinator/unified_price_manager.py
+++ b/custom_components/ge_spot/coordinator/unified_price_manager.py
@@ -515,6 +515,37 @@ class UnifiedPriceManager:
             # Always clear flag when done
             self._health_check_in_progress = False
 
+    def _price_config_changed(self, cached_price_data) -> bool:
+        """Whether the current price config differs from the cached data's.
+
+        Cached prices are fully processed (VAT/multiplier/tariff/tax baked in), so
+        an option change must invalidate the cache and trigger a reprocess. Cached
+        data from before this stamp existed defaults to 0.0/False/1.0, which simply
+        forces one reprocess for non-default configs (self-healing).
+        """
+        if cached_price_data is None or self._data_processor is None:
+            return False
+        dp = self._data_processor
+        tol = 1e-9
+        try:
+            return (
+                abs(cached_price_data.applied_vat_rate - dp.vat_rate) > tol
+                or bool(cached_price_data.applied_include_vat) != bool(dp.include_vat)
+                or abs(
+                    cached_price_data.applied_import_multiplier - dp.import_multiplier
+                )
+                > tol
+                or abs(
+                    cached_price_data.applied_additional_tariff - dp.additional_tariff
+                )
+                > tol
+                or abs(cached_price_data.applied_energy_tax - dp.energy_tax) > tol
+            )
+        except (TypeError, AttributeError):
+            # Config values not comparable (e.g. mocked in tests, or missing):
+            # fail safe to serving the cache rather than forcing a refetch.
+            return False
+
     async def fetch_data(self, force: bool = False) -> Dict[str, Any]:
         """Fetch price data with implicit source validation.
 
@@ -606,7 +637,20 @@ class UnifiedPriceManager:
                 f"[{self.area}] Health check bypassing rate limit (reason: {fetch_reason})"
             )
 
-        if not force and not should_fetch_from_api:
+        # Cached prices bake in VAT/multiplier/tariff/tax. If the current price
+        # config differs from what the cache was computed with, the cache is stale
+        # and must be reprocessed (otherwise option changes only take effect after
+        # an HA restart). Treat this like force=True so a fresh fetch + reprocess
+        # runs (which also bypasses the rate limit, avoiding a data gap).
+        price_config_changed = self._price_config_changed(cached_price_data)
+        if price_config_changed:
+            _LOGGER.info(
+                "[%s] Price config changed since cache was computed; "
+                "reprocessing instead of serving stale cache.",
+                self.area,
+            )
+
+        if not force and not price_config_changed and not should_fetch_from_api:
             _LOGGER.debug(f"Skipping API fetch for area {self.area}: {fetch_reason}")
             if cached_price_data:
                 _LOGGER.debug("Returning cached data for %s", self.area)

--- a/tests/pytest/unit/test_cache_price_config_invalidation.py
+++ b/tests/pytest/unit/test_cache_price_config_invalidation.py
@@ -1,0 +1,93 @@
+"""Regression: a price-affecting option change must invalidate the cache.
+
+Cached prices are fully processed (VAT/multiplier/tariff/tax baked in). When a
+price option changes, ``UnifiedPriceManager._price_config_changed`` must return
+True so ``fetch_data`` reprocesses instead of serving stale prices — otherwise
+the change only takes effect after an HA restart.
+"""
+
+from custom_components.ge_spot.coordinator.unified_price_manager import (
+    UnifiedPriceManager,
+)
+from custom_components.ge_spot.coordinator.data_models import IntervalPriceData
+
+
+class _DataProcessorStub:
+    def __init__(
+        self,
+        vat_rate=0.25,
+        include_vat=True,
+        import_multiplier=1.0,
+        additional_tariff=0.0,
+        energy_tax=0.0,
+    ):
+        self.vat_rate = vat_rate
+        self.include_vat = include_vat
+        self.import_multiplier = import_multiplier
+        self.additional_tariff = additional_tariff
+        self.energy_tax = energy_tax
+
+
+def _manager(dp):
+    # Bypass __init__ (needs hass/session); the method only uses _data_processor.
+    mgr = UnifiedPriceManager.__new__(UnifiedPriceManager)
+    mgr._data_processor = dp
+    return mgr
+
+
+def _cached(**overrides):
+    base = dict(
+        applied_vat_rate=0.25,
+        applied_include_vat=True,
+        applied_import_multiplier=1.0,
+        applied_additional_tariff=0.0,
+        applied_energy_tax=0.0,
+    )
+    base.update(overrides)
+    return IntervalPriceData(**base)
+
+
+def test_unchanged_config_keeps_cache():
+    assert _manager(_DataProcessorStub())._price_config_changed(_cached()) is False
+
+
+def test_vat_change_invalidates():
+    mgr = _manager(_DataProcessorStub(vat_rate=0.50))
+    assert mgr._price_config_changed(_cached(applied_vat_rate=0.25)) is True
+
+
+def test_multiplier_change_invalidates():
+    mgr = _manager(_DataProcessorStub(import_multiplier=0.5))
+    assert mgr._price_config_changed(_cached()) is True
+
+
+def test_tariff_and_tax_changes_invalidate():
+    assert (
+        _manager(_DataProcessorStub(additional_tariff=0.1))._price_config_changed(
+            _cached()
+        )
+        is True
+    )
+    assert (
+        _manager(_DataProcessorStub(energy_tax=0.05))._price_config_changed(_cached())
+        is True
+    )
+
+
+def test_include_vat_toggle_invalidates():
+    mgr = _manager(_DataProcessorStub(include_vat=False, vat_rate=0.0))
+    assert mgr._price_config_changed(_cached(applied_include_vat=True)) is True
+
+
+def test_none_cache_is_not_a_change():
+    assert _manager(_DataProcessorStub())._price_config_changed(None) is False
+
+
+def test_legacy_cache_without_stamps_self_heals():
+    # Cache stored before this fix has applied_* at defaults (0.0/False/1.0);
+    # for a non-default config this must force exactly one reprocess.
+    legacy = IntervalPriceData()
+    assert (
+        _manager(_DataProcessorStub(vat_rate=0.25))._price_config_changed(legacy)
+        is True
+    )


### PR DESCRIPTION
## Problem
Changing a price-affecting option (VAT, import multiplier, additional tariff, energy tax) does **not** take effect until a full HA restart. Reproduced live + traced in debug logs:
- The cache stores **fully-processed (VAT-baked) prices** and `fetch_data` serves them directly ("no reprocessing needed", from #48 "simplify cache").
- On an options change, `options.py` calls `coordinator.clear_cache()` — but it runs on the **old, pre-reload coordinator**, so it re-bakes the cache with the **old** config. Debug log proof: the reloaded coordinator logs `VAT will be applied: 50.0%` yet still logs `Returning cached data` (old VAT).

## Constraint respected
The forced refetch in `clear_cache` exists on purpose: `fetch_decision.should_fetch` honours the 15-min rate limit, so a naive "clear without refetch" could leave sensors **unavailable up to 15 min**. This fix keeps a forced fetch (no data gap).

## Fix (Option A — config-aware cache, per maintainer steer)
- Stamp each cached `IntervalPriceData` with the price config actually applied (`applied_vat_rate`, `applied_include_vat`, `applied_import_multiplier`, `applied_additional_tariff`, `applied_energy_tax`), persisted through `to_cache_dict`/`from_cache_dict`.
- In `fetch_data`, if the live config differs from the cached stamp (`_price_config_changed`), bypass the stale cache → fresh fetch + reprocess (bypasses the rate limit, so no gap). Fail-safe `try/except` so a non-comparable config (e.g. mocked) serves the cache as before.
- Cache stays fully effective for normal reads. Legacy cache (no stamps) self-heals with one reprocess.

## Testing
- New `tests/pytest/unit/test_cache_price_config_invalidation.py`: VAT / multiplier / tariff / tax changes, `include_vat` toggle, None cache, legacy-cache self-heal — all pass.
- Full unit suite: **458 passed**. `black` clean.
- **Exonerated** vs the separate midnight outage (that reproduces on `main` with these changes removed).

## Please review before merge
This touches the (deliberately designed) cache path you flagged as sensitive. Recommend a quick live check before merging: change an area's VAT in the UI and confirm the price updates **without** a restart. Does **not** touch the separate nordpool midnight date-rollover bug (tracked separately).