### PR TITLE
Fetch Nord Pool prices using the CET delivery date, not the UTC date

### DIFF
--- a/custom_components/ge_spot/api/nordpool.py
+++ b/custom_components/ge_spot/api/nordpool.py
@@ -118,12 +118,18 @@ class NordpoolAPI(BasePriceAPI):
         # Check if we need extended date ranges due to timezone offset
         extended_ranges = self.needs_extended_date_range("Europe/Oslo", reference_time)
 
+        # Nordpool's "date" parameter is the delivery date in the market's local
+        # (CET/CEST) time, so compute these dates in that timezone rather than UTC.
+        # Just after local midnight (CET date > UTC date) a UTC-based date would
+        # request the previous delivery day, leaving today's prices empty (~2 h).
+        delivery_tz = get_timezone_object("Europe/Oslo")
+
         # Fetch yesterday's data if needed
         yesterday_data = None
         if extended_ranges["need_yesterday"]:
-            yesterday = (reference_time - timedelta(days=1)).strftime(
-                TimeFormat.DATE_ONLY
-            )
+            yesterday = (
+                reference_time.astimezone(delivery_tz) - timedelta(days=1)
+            ).strftime(TimeFormat.DATE_ONLY)
             params_yesterday = {
                 "currency": Currency.EUR,
                 "date": yesterday,
@@ -137,7 +143,7 @@ class NordpoolAPI(BasePriceAPI):
 
         # Fetch today's data (first range is today to tomorrow)
         today_start, today_end = date_ranges[0]
-        today = today_start.strftime(TimeFormat.DATE_ONLY)
+        today = today_start.astimezone(delivery_tz).strftime(TimeFormat.DATE_ONLY)
 
         params_today = {
             "currency": Currency.EUR,
@@ -163,10 +169,10 @@ class NordpoolAPI(BasePriceAPI):
         should_fetch_tomorrow = now_cet.hour >= release_hour_cet
 
         if should_fetch_tomorrow:
-            # Always compute tomorrow as reference_time + 1 day
-            tomorrow = (reference_time + timedelta(days=1)).strftime(
-                TimeFormat.DATE_ONLY
-            )
+            # Always compute tomorrow as the delivery-area local day + 1
+            tomorrow = (
+                reference_time.astimezone(delivery_tz) + timedelta(days=1)
+            ).strftime(TimeFormat.DATE_ONLY)
             params_tomorrow = {
                 "currency": Currency.EUR,
                 "date": tomorrow,

--- a/tests/pytest/unit/test_nordpool_cet_delivery_date.py
+++ b/tests/pytest/unit/test_nordpool_cet_delivery_date.py
@@ -1,0 +1,56 @@
+"""Regression: Nord Pool must request the delivery date in CET, not UTC.
+
+Nord Pool's ``date`` query parameter is the delivery date in the market's local
+(CET/CEST) time. Computing it from the UTC date means that for the ~2 hours
+after local midnight (when the CET date is already the next day but UTC is not),
+the integration requests the previous delivery day — so the new day's prices are
+classified as "neither today nor tomorrow" and every nordpool area shows no price
+until UTC catches up. These tests freeze the clock across that boundary.
+"""
+
+from unittest.mock import AsyncMock
+
+from custom_components.ge_spot.api.nordpool import NordpoolAPI
+
+
+def _client_capturing_dates():
+    calls = []
+
+    async def fake_fetch(url, params=None, **kwargs):
+        calls.append((params or {}).get("date"))
+        # Non-empty so the tomorrow-availability check treats it as published
+        # (an empty list would trigger fetch_with_retry's retry loop).
+        return {"multiAreaEntries": [{}]}
+
+    client = AsyncMock()
+    client.fetch = AsyncMock(side_effect=fake_fetch)
+    return client, calls
+
+
+async def _dates_fetched():
+    api = NordpoolAPI()
+    client, calls = _client_capturing_dates()
+    try:
+        await api._fetch_data(client, "SE4", reference_time=None)
+    except Exception:  # pragma: no cover - we only assert the captured params
+        pass
+    return calls
+
+
+async def test_uses_cet_date_just_after_local_midnight(freezer):
+    # 22:08 UTC == 00:08 Oslo (CEST) on the next calendar day.
+    freezer.move_to("2026-06-26 22:08:00")
+    dates = await _dates_fetched()
+    # The "today" delivery date must be the CET date (2026-06-27), NOT the UTC
+    # date (2026-06-26). Before the fix, only 2026-06-26 was ever requested.
+    assert "2026-06-27" in dates, f"expected CET today 2026-06-27 in {dates}"
+    assert "2026-06-26" not in dates, f"must not request UTC date 2026-06-26: {dates}"
+
+
+async def test_daytime_date_unchanged(freezer):
+    # 12:00 UTC == 14:00 Oslo (CEST), same calendar day as UTC.
+    freezer.move_to("2026-06-26 12:00:00")
+    dates = await _dates_fetched()
+    # Today is unchanged (2026-06-26); past 13:00 CET tomorrow is also requested.
+    assert "2026-06-26" in dates, f"expected today 2026-06-26 in {dates}"
+    assert "2026-06-27" in dates, f"expected tomorrow 2026-06-27 in {dates}"


### PR DESCRIPTION
## Problem (the nightly post-midnight outage)
Observed live on this devbox: for ~2 hours after local midnight, **every** nordpool area dropped to no current price (`today=0`), recovering on its own around 02:00 local. Root cause traced in [api/nordpool.py](custom_components/ge_spot/api/nordpool.py):

- Nord Pool's `date` query parameter is the **delivery date in the market's local (CET/CEST) time**. Verified against the live API: `date=2026-06-27` returns intervals starting `2026-06-26T22:00Z` (= 00:00 Oslo on the 27th).
- The fetch computed `today`/`yesterday`/`tomorrow` from the **UTC** date (`reference_time = datetime.now(timezone.utc)`). CET is always ahead of UTC, so between local midnight and UTC midnight the CET date is already the next day while the UTC date is not — the code requested the **previous** delivery day. The new day's intervals were then classified as neither today nor tomorrow → empty sensors until UTC caught up.

This is independent of the cache (reproduces on a cold fetch) and independent of #94.

## Fix
Compute the three `date` parameters in the delivery-area timezone (Europe/Oslo = CET/CEST, always ≥ UTC) instead of UTC. Daytime behaviour is unchanged (CET date == UTC date); only the post-midnight window is corrected. The change is bounded: it can only ever move the requested date forward by at most one day, and only during that window.

## Testing
- New `tests/pytest/unit/test_nordpool_cet_delivery_date.py` uses a **frozen clock** (pytest-freezer) so the boundary is verified deterministically — no need to wait for real midnight:
  - 00:08 CET (22:08 UTC): the today date must be the CET day `2026-06-27`, **not** the UTC day `2026-06-26`. **Fails on `main`, passes with this fix.**
  - 14:00 CET: daytime requests unchanged (today `2026-06-26`, tomorrow `2026-06-27`).
- Full unit suite: **453 passed**. `black` clean. Pylint 9.75 on the file (only the pre-existing `today_end` unused-var, untouched by this change).

## Please review before merge
High blast radius (every nordpool fetch / every nordpool user), so flagging for review rather than self-merging. Single concern; does not touch the pre-existing `today_end` dead var or the cache path (#94).