### PR TITLE
Guard get_expected_intervals_for_date against a missing timezone (fixes blocking-call warning)

### DIFF
--- a/custom_components/ge_spot/const/time.py
+++ b/custom_components/ge_spot/const/time.py
@@ -108,19 +108,26 @@ class TimeInterval:
         # Import here to avoid circular dependency (DSTHandler uses TimeInterval)
         from ..timezone.dst_handler import DSTHandler
 
-        # Normalize timezone to ZoneInfo object
-        # Handle both string and ZoneInfo inputs (also handles str() conversion for other types)
-        if isinstance(timezone_str, str):
-            tz = ZoneInfo(timezone_str)
-        elif isinstance(timezone_str, ZoneInfo):
+        # Normalize timezone to a ZoneInfo object.
+        if isinstance(timezone_str, ZoneInfo):
             tz = timezone_str
+        elif isinstance(timezone_str, str):
+            if not timezone_str or timezone_str == "None":
+                # Missing/invalid timezone name: we cannot determine DST
+                # transitions, so assume a normal day. Avoids ZoneInfo("None"),
+                # which both fails (no such zone) and blocks the event loop.
+                return TimeInterval.get_intervals_per_day()  # 96
+            tz = ZoneInfo(timezone_str)
+        elif timezone_str is None:
+            # No timezone provided (e.g. an area whose timezone service has not
+            # resolved a zone): assume a normal day rather than crashing or
+            # doing a blocking ZoneInfo("None") load inside the event loop.
+            return TimeInterval.get_intervals_per_day()  # 96
         else:
-            # If it's some other type (like a Mock or unknown object), try to convert to string first
-            try:
-                tz = ZoneInfo(str(timezone_str))
-            except Exception:
-                # Last resort: assume it's already a timezone-like object
-                tz = timezone_str
+            # Some other timezone-like object (e.g. a tzinfo instance); use it
+            # directly instead of ZoneInfo(str(obj)), which would block the event
+            # loop and fail for objects whose str() is not a valid zone name.
+            tz = timezone_str
 
         # Create timezone-aware datetime if needed
         if hasattr(date, "tzinfo") and date.tzinfo is None:

--- a/tests/pytest/unit/test_time_expected_intervals_timezone.py
+++ b/tests/pytest/unit/test_time_expected_intervals_timezone.py
@@ -1,0 +1,72 @@
+"""Regression: get_expected_intervals_for_date must handle missing timezones.
+
+When an area's timezone service has not resolved a zone, the caller passes
+``None`` (or the string ``"None"``). The old code reached ``ZoneInfo("None")``,
+which triggered a blocking tzdata load inside the event loop (Home Assistant
+flags this as a blocking call) before failing/raising. The fix returns a normal
+(96-interval) day at a guard, BEFORE constructing any ZoneInfo or DSTHandler.
+
+These tests patch DSTHandler to assert that early-return path is taken for
+missing timezones, and leave it real for valid zones to confirm DST detection
+still works.
+"""
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+from unittest.mock import patch
+
+from custom_components.ge_spot.const.time import TimeInterval
+
+NORMAL = TimeInterval.get_intervals_per_day()  # 96
+
+
+def _intervals_guarded(tz_value):
+    """For a missing timezone the helper must return before touching DSTHandler.
+
+    DSTHandler is imported inside the function from its source module, so we
+    patch it there. If the guard is removed, the function either constructs a
+    DSTHandler (None case) or raises in ZoneInfo (the "None"/"" cases) — both
+    fail this helper.
+    """
+    with patch(
+        "custom_components.ge_spot.timezone.dst_handler.DSTHandler"
+    ) as dst_handler:
+        result = TimeInterval.get_expected_intervals_for_date(
+            datetime(2026, 6, 27), tz_value
+        )
+        dst_handler.assert_not_called()
+    return result
+
+
+def test_none_timezone_returns_at_guard():
+    assert _intervals_guarded(None) == NORMAL
+
+
+def test_string_none_returns_at_guard():
+    assert _intervals_guarded("None") == NORMAL
+
+
+def test_empty_string_returns_at_guard():
+    assert _intervals_guarded("") == NORMAL
+
+
+def test_valid_zoneinfo_object_still_works():
+    result = TimeInterval.get_expected_intervals_for_date(
+        datetime(2026, 6, 27), ZoneInfo("Europe/Stockholm")
+    )
+    assert result == NORMAL
+
+
+def test_valid_string_still_works():
+    result = TimeInterval.get_expected_intervals_for_date(
+        datetime(2026, 6, 27), "Europe/Stockholm"
+    )
+    assert result == NORMAL
+
+
+def test_dst_transition_day_still_detected_with_valid_zone():
+    # 2026-03-29 is the European spring-forward day (92 intervals).
+    result = TimeInterval.get_expected_intervals_for_date(
+        datetime(2026, 3, 29), "Europe/Stockholm"
+    )
+    assert result == TimeInterval.get_intervals_per_day_dst_spring()  # 92


### PR DESCRIPTION
## Problem (from the live HA Core log)
HA logged a **blocking-call** warning with full traceback for affected areas:
```
Detected blocking call to import_module with args ('tzdata.zoneinfo',) inside the event loop
by custom integration 'ge_spot' at custom_components/ge_spot/const/time.py, line 120:
tz = ZoneInfo(str(timezone_str))
```
`data_processor.process()` calls `get_expected_intervals_for_date(today_date, self._tz_service.area_timezone)`. When an area's timezone service hasn't resolved a zone, `area_timezone` is `None`, so the helper fell through to `ZoneInfo(str(None))` == `ZoneInfo("None")` — which both (a) is an invalid zone and (b) does a **blocking tzdata load inside the event loop** (HA flags this), logged per affected area.

## Fix
[const/time.py](custom_components/ge_spot/const/time.py): return a normal-day count (96) at a guard for `None` / `""` / the literal `"None"` **before** constructing any `ZoneInfo`, and use a non-string tz-like object directly instead of `ZoneInfo(str(obj))`. Valid `str` and `ZoneInfo` inputs — including DST-transition days — are unchanged.

## Testing
- New `tests/pytest/unit/test_time_expected_intervals_timezone.py`: missing-timezone cases return at the guard (no `DSTHandler`/`ZoneInfo` construction — **fails without the fix**), valid zones still count correctly, and the spring-forward day still returns 92.
- Full unit suite: **457 passed**. `black` clean.

## Note
Low blast radius (pure helper; only changes the previously-crashing missing-timezone path). Separately, *why* an area's `area_timezone` is `None` is worth a follow-up, but this stops the blocking call + invalid lookup regardless.