### PR TITLE
Stop logging transient upstream 5xx (503) as ERROR with HTML bodies

### DIFF
--- a/custom_components/ge_spot/api/base/api_client.py
+++ b/custom_components/ge_spot/api/base/api_client.py
@@ -37,6 +37,7 @@ class ApiClient:
         self._headers = {"User-Agent": "GE-Spot/1.0", "Accept": "application/json"}
         self._consecutive_error_counts = {}
         self._rate_limit_detected = {}
+        self._server_error_detected = {}
 
     async def get(
         self,
@@ -161,6 +162,18 @@ class ApiClient:
                                 f"Rate limited (HTTP 429), will fall back / "
                                 f"retry later: {url}"
                             )
+                        elif response.status in (502, 503, 504):
+                            # Transient upstream unavailability (bad gateway /
+                            # service unavailable / gateway timeout). Retried by
+                            # the fetch/fallback path; _track_error_response
+                            # surfaces one WARNING per source, so keep the
+                            # per-request detail at DEBUG to avoid flooding the
+                            # log during an upstream outage (e.g. ENTSO-E 503s).
+                            _LOGGER.debug(
+                                f"Upstream temporarily unavailable "
+                                f"(HTTP {response.status}), will retry / "
+                                f"fall back: {url}"
+                            )
                         else:
                             _LOGGER.error(
                                 f"API request failed with status {response.status}: {url}"
@@ -253,6 +266,15 @@ class ApiClient:
                     f"Integration will automatically retry later."
                 )
             self._rate_limit_detected[url_key] = True
+        elif status_code in (502, 503, 504):
+            # Transient upstream unavailability: surface one WARNING per source
+            # (reset on the next success) instead of an ERROR per request.
+            if url_key not in self._server_error_detected:
+                _LOGGER.warning(
+                    f"Upstream temporarily unavailable (HTTP {status_code}) for "
+                    f"{url_key}. Transient; integration will retry / fall back."
+                )
+            self._server_error_detected[url_key] = True
         elif status_code == 404:
             # Track consecutive 404s which may indicate rate limiting
             self._consecutive_error_counts[url_key] = (
@@ -278,6 +300,8 @@ class ApiClient:
             del self._consecutive_error_counts[url_key]
         if url_key in self._rate_limit_detected:
             del self._rate_limit_detected[url_key]
+        if url_key in self._server_error_detected:
+            del self._server_error_detected[url_key]
 
     async def close(self) -> None:
         """No-op: the aiohttp session is injected and owned by the caller.

--- a/custom_components/ge_spot/api/entsoe.py
+++ b/custom_components/ge_spot/api/entsoe.py
@@ -245,17 +245,27 @@ class EntsoeAPI(BasePriceAPI):
                     if isinstance(response, dict) and response.get("error"):
                         status_code = response.get("status_code")
                         message = response.get("message", "Unknown API error")
-                        _LOGGER.error(
-                            f"ENTSO-E API error (status {status_code}) for doc_type={doc_type}, range={period_start}-{period_end}: {message}"
-                        )
                         if status_code == 401:
-                            # Raise specific error for auth failure, including message from API if available
+                            # Auth failure is actionable by the user — log at ERROR
+                            # and raise so the caller surfaces it.
+                            _LOGGER.error(
+                                f"ENTSO-E API authentication failed (401 Unauthorized) "
+                                f"for area {area}. Check your API key."
+                            )
                             raise ValueError(
                                 f"ENTSO-E API authentication failed (401 Unauthorized). Check your API key. Message: {message}"
                             )
-                        else:
-                            # For other HTTP errors (e.g. 400, 500), log and continue to the next attempt
-                            continue  # Go to next doc_type/date_range
+                        # Other HTTP errors (e.g. transient 503s during an ENTSO-E
+                        # outage) are retried and handled by the fallback path; the
+                        # api_client already surfaces one WARNING per source. Log at
+                        # DEBUG without the (often HTML) response body to avoid
+                        # flooding the log.
+                        _LOGGER.debug(
+                            f"ENTSO-E non-OK response (status {status_code}) for "
+                            f"doc_type={doc_type}, range={period_start}-{period_end}; "
+                            f"trying next."
+                        )
+                        continue  # Go to next doc_type/date_range
 
                     # --- Handle Non-Error Responses ---
                     # If it wasn't an error dict, proceed with normal checks

--- a/tests/pytest/unit/test_api_client_rate_limit.py
+++ b/tests/pytest/unit/test_api_client_rate_limit.py
@@ -71,3 +71,36 @@ async def test_500_still_logged_as_error(caplog):
     assert any(
         "status 500" in m for m in errors
     ), f"500 should log ERROR, got: {errors}"
+
+
+async def test_503_not_logged_as_error(caplog):
+    """A transient 503 (upstream outage) returns the error dict, no ERROR record."""
+    client = ApiClient(
+        session=_FakeSession(_FakeResponse(503, body="<html>service down</html>"))
+    )
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG):
+        result = await client.fetch("https://web-api.tp.entsoe.eu/api")
+
+    assert result.get("error") is True
+    assert result.get("status_code") == 503
+    errors = [r.message for r in caplog.records if r.levelname == "ERROR"]
+    assert errors == [], f"503 must not log ERROR, got: {errors}"
+
+
+async def test_503_surfaces_single_warning(caplog):
+    """Repeated 503s to the same source warn once (per source), not per request."""
+    client = ApiClient(session=_FakeSession(_FakeResponse(503, body="down")))
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG):
+        await client.fetch("https://web-api.tp.entsoe.eu/api?doc=A44&x=1")
+        await client.fetch("https://web-api.tp.entsoe.eu/api?doc=A44&x=2")
+
+    warnings = [
+        r.message
+        for r in caplog.records
+        if r.levelname == "WARNING" and "Upstream temporarily unavailable" in r.message
+    ]
+    assert len(warnings) == 1, f"expected exactly one WARNING, got: {warnings}"


### PR DESCRIPTION
## Problem (from the live HA Core log)
During an ENTSO-E outage (~02:30–04:30) the Core log filled with **~1000 ERROR lines**:
- `api_client`: `API request failed with status 503: <url>` — **538×**
- `entsoe`: `ENTSO-E API error (status 503) for doc_type=A44 ...: <!doctype html><html>...` — **458×**, each dumping the **full HTML error body**.

These are transient upstream unavailability that the fetch/fallback path already retries and recovers from (SE4 and others stayed correct throughout) — not actionable errors. They also drowned out the real signal, which is exactly why "no errors" was the wrong read.

## Fix
Mirror the existing 429 handling (#91) for the **502/503/504** (bad gateway / service unavailable / gateway timeout) family:
- [api_client.py](custom_components/ge_spot/api/base/api_client.py): per-request detail → DEBUG; surface **one WARNING per source** via `_track_error_response` (new `_server_error_detected`, reset on success). Genuine **500s still log ERROR** (unchanged).
- [entsoe.py](custom_components/ge_spot/api/entsoe.py): only **401** (auth, user-actionable) logs ERROR and raises; other non-OK responses log at DEBUG **without the HTML body**.

## Testing
- [test_api_client_rate_limit.py](tests/pytest/unit/test_api_client_rate_limit.py): 503 logs **no ERROR** and warns **exactly once** per source (de-duped by base URL); 500 still ERRORs; 429 unchanged.
- Full unit suite: **453 passed**. `black` clean.

## Scope
Single concern (transient 5xx log level). Does not change retry/fallback behavior — only log level + dropping HTML bodies. Separate from the rate-limit-decision WARNING spam (`fetch_decision`), which I'm addressing in its own PR.