### PR TITLE
Log 'Low on data but rate limited' at INFO, not WARNING

### DIFF
--- a/custom_components/ge_spot/coordinator/fetch_decision.py
+++ b/custom_components/ge_spot/coordinator/fetch_decision.py
@@ -162,7 +162,12 @@ class FetchDecisionMaker:
 
             if should_skip:
                 reason = f"Low on data but rate limited: {skip_reason}"
-                _LOGGER.warning(reason)
+                # INFO, not WARNING: this is the rate limiter working as intended
+                # (we recently fetched). It is logged every update cycle for each
+                # affected area, and its siblings above ("no current interval data
+                # but rate limited", "special window but rate limited") are INFO
+                # too — surfacing it at WARNING flooded the log during outages.
+                _LOGGER.info(reason)
                 return False, reason
 
             return True, reason

--- a/tests/pytest/unit/test_fetch_decision_low_data_log_level.py
+++ b/tests/pytest/unit/test_fetch_decision_low_data_log_level.py
@@ -1,0 +1,54 @@
+"""Regression: 'Low on data but rate limited' must not be logged at WARNING.
+
+When an area is low on data but was fetched recently, the rate limiter correctly
+skips the fetch. That is expected operation (its sibling skip-reasons in
+FetchDecisionMaker are INFO), but it was logged at WARNING and fired every update
+cycle for every affected area — flooding the Core log's warning view during
+upstream outages. It must log at INFO.
+"""
+
+import logging
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+from custom_components.ge_spot.coordinator.fetch_decision import FetchDecisionMaker
+
+
+def _low_data_rate_limited_decision(caplog):
+    decision = FetchDecisionMaker(tz_service=MagicMock())
+    now = datetime(2026, 6, 27, 12, 0, tzinfo=timezone.utc)
+
+    data_validity = MagicMock()
+    data_validity.has_current_interval = True  # pass the critical check
+    data_validity.intervals_remaining.return_value = 0  # below the safety buffer
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG):
+        need_fetch, reason = decision.should_fetch(
+            now=now,
+            last_fetch=now - timedelta(minutes=1),  # recent -> rate limited
+            data_validity=data_validity,
+            fetch_interval_minutes=15,
+            in_grace_period=False,
+        )
+    return need_fetch, reason
+
+
+def test_low_on_data_rate_limited_does_not_warn(caplog):
+    need_fetch, reason = _low_data_rate_limited_decision(caplog)
+
+    assert need_fetch is False
+    assert "Low on data but rate limited" in reason
+    warnings = [r.message for r in caplog.records if r.levelname == "WARNING"]
+    assert warnings == [], f"must not log WARNING, got: {warnings}"
+
+
+def test_low_on_data_rate_limited_logged_at_info(caplog):
+    _low_data_rate_limited_decision(caplog)
+
+    infos = [
+        r.message
+        for r in caplog.records
+        if r.levelname == "INFO" and "Low on data but rate limited" in r.message
+    ]
+    assert len(infos) == 1, f"expected one INFO line, got: {infos}"


### PR DESCRIPTION
## Problem (from the live HA Core log)
`Low on data but rate limited: Last fetch was only N minutes ago (minimum: 15)` appeared **~368×** in the warning view. It fires every update cycle for every area that is low on data but was fetched within the minimum interval — i.e. the rate limiter working **as intended**.

Its sibling skip-reasons in [fetch_decision.py](custom_components/ge_spot/coordinator/fetch_decision.py) are already INFO:
- `No current interval data, but rate limited (...)` → INFO (and that's the *worse* case — no data at all)
- `Special window but rate limited (...)` → INFO

So WARNING here is miscalibrated and floods the warning view during any period of repeated rate-limiting (e.g. the ENTSO-E outage).

## Fix
Log the low-on-data + rate-limited skip at **INFO**, matching its siblings. No behavior change (still returns `(False, reason)` and skips the fetch).

## Testing
- New [test_fetch_decision_low_data_log_level.py](tests/pytest/unit/test_fetch_decision_low_data_log_level.py): the low-on-data + rate-limited path logs **INFO, not WARNING** (fails before the change).
- Full unit suite: **453 passed**. `black` clean.

Single concern; one log level. Part of cleaning up the Core warning view alongside #97 (transient 5xx) and #96 (blocking-call guard).