### PR TITLE
Remove dead code: unused with_error_handling decorator + tomorrow_date var (#13, #19)

### DIFF
--- a/custom_components/ge_spot/api/base/error_handler.py
+++ b/custom_components/ge_spot/api/base/error_handler.py
@@ -12,47 +12,6 @@ from ...const.network import Network, NetworkErrorType, RetryStrategy
 _LOGGER = logging.getLogger(__name__)
 
 
-def with_error_handling(func=None, *, source_type: str = "unknown"):
-    """Decorator to handle errors in API calls.
-
-    Can be used as a decorator with or without arguments:
-
-    @with_error_handling
-    async def my_func():
-        ...
-
-    @with_error_handling(source_type="my_source")
-    async def my_func():
-        ...
-
-    Args:
-        func: The function to decorate
-        source_type: The source type identifier
-
-    Returns:
-        Decorated function
-    """
-    # Used as a decorator with arguments @with_error_handling(...)
-    if func is None:
-        return functools.partial(with_error_handling, source_type=source_type)
-
-    # For direct function calls or @with_error_handling without arguments
-    @functools.wraps(func)
-    async def wrapper(*args, **kwargs):
-        handler = ErrorHandler(source_type)
-        try:
-            return await func(*args, **kwargs)
-        except Exception as error:
-            error_type = handler.classify_error(error)
-            _LOGGER.error(
-                f"Error in {source_type} API call: {error}. "
-                f"Classified as {error_type}."
-            )
-            raise error
-
-    return wrapper
-
-
 def retry_with_backoff(
     func=None,
     *,

--- a/custom_components/ge_spot/coordinator/fetch_decision.py
+++ b/custom_components/ge_spot/coordinator/fetch_decision.py
@@ -5,7 +5,7 @@ Instead of asking "do we have complete data?", we ask "how long is our data vali
 """
 
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Any, Optional, Tuple
 
 from ..const.network import Network
@@ -173,9 +173,6 @@ class FetchDecisionMaker:
         start_hour, end_hour = Network.Defaults.SPECIAL_HOUR_WINDOWS[1]
 
         if start_hour <= hour < end_hour:
-            # Check if we already have tomorrow's complete data
-            tomorrow_date = now.date() + timedelta(days=1)
-
             # Check against the required interval threshold (76 intervals = 80% of 96)
             if (
                 data_validity.tomorrow_interval_count


### PR DESCRIPTION
Two grep-verified dead-code removals:
- [api/base/error_handler.py](custom_components/ge_spot/api/base/error_handler.py): `with_error_handling` decorator has **0 references** (never applied). `retry_with_backoff` and the `ErrorHandler` class (both used) are kept. *(finding #13)*
- [coordinator/fetch_decision.py](custom_components/ge_spot/coordinator/fetch_decision.py): `tomorrow_date` in the special-window branch was computed but never read (the branch uses `data_validity.tomorrow_interval_count`); drops it and the now-unused `timedelta` import. *(finding #19)*

Pure dead-code removal, no behavior change. `black` clean; no new unused-import/var.

### ⚠️ Heads-up: a pre-existing failing test on `main`
While running the suite I found `test_dst_validation.py::TestApiValidatorDSTAware::test_spring_forward_validation_without_timezone` **fails on clean main** (450 passed, 1 failed) — **not** caused by this PR. Root cause: the test builds data for hours 0–22 and `ApiValidator.is_data_adequate(..., require_current_hour=True)` rejects it whenever the current wall-clock interval key falls outside that range — i.e. it's a **time-of-day-fragile** test of `ApiValidator`, which is itself unused/dead code (audit #14). Recommend resolving via #14 (remove the dead `ApiValidator` + its test) or making the test deterministic. Flagging separately.