### PR TITLE
Fix operator-precedence bug: localize naive ISO timestamps (#8)

### DIFF
--- a/custom_components/ge_spot/timezone/parser.py
+++ b/custom_components/ge_spot/timezone/parser.py
@@ -149,12 +149,13 @@ class TimestampParser:
                     if str(source_tz) != "UTC":
                         dt = dt.astimezone(source_tz)
                     return dt
-                elif (
-                    "+" in timestamp_str
-                    or "-" in timestamp_str
-                    and "T" in timestamp_str
-                ):
-                    # ISO with timezone offset
+                elif re.search(r"[+-]\d{2}:?\d{2}$", timestamp_str):
+                    # ISO with an explicit timezone offset suffix (e.g. +02:00,
+                    # -0500). Detect a real trailing offset rather than any "+"/
+                    # "-": the date part always contains "-", so the old
+                    # `"+" in s or "-" in s and "T" in s` test (and binds tighter
+                    # than or) sent NAIVE ISO timestamps down this branch and
+                    # returned them without attaching the source timezone.
                     dt = datetime.fromisoformat(timestamp_str)
                     # Convert to source timezone if needed
                     if dt.tzinfo and dt.tzinfo != source_tz:

--- a/tests/pytest/unit/test_parser_iso_offset.py
+++ b/tests/pytest/unit/test_parser_iso_offset.py
@@ -1,0 +1,45 @@
+"""Regression: naive ISO timestamps must be localized to the source timezone.
+
+TimestampParser.parse() has a general-ISO branch. The offset-detection used
+`"+" in s or "-" in s and "T" in s`; because `and` binds tighter than `or` and
+the branch already runs under `if "T" in s`, this reduced to `"+" in s or
+"-" in s`. A naive ISO like "2025-03-30T10:00:00" contains "-" (date separators),
+so it wrongly took the "has offset" path and was returned NAIVE instead of being
+localized to the source timezone. Only a real trailing offset (+HH:MM / -HHMM)
+should take that path.
+"""
+
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+from custom_components.ge_spot.timezone.parser import TimestampParser
+
+
+def test_naive_iso_gets_source_timezone_attached():
+    result = TimestampParser().parse("2025-03-30T10:00:00", "Europe/Stockholm")
+    # Must be timezone-aware (the bug returned a naive datetime).
+    assert result.tzinfo is not None, "naive ISO must be localized, got naive"
+    # Wall-clock time is unchanged; the source timezone is attached.
+    assert (result.hour, result.minute) == (10, 0)
+    assert result.utcoffset() == ZoneInfo("Europe/Stockholm").utcoffset(
+        datetime(2025, 3, 30, 10, 0)
+    )
+
+
+def test_iso_with_offset_is_preserved_and_converted():
+    # 10:00+05:00 == 05:00 UTC; converted into Europe/Stockholm it is the same
+    # instant (07:00 CEST on 2025-03-30).
+    result = TimestampParser().parse("2025-03-30T10:00:00+05:00", "Europe/Stockholm")
+    assert result.tzinfo is not None
+    assert result.astimezone(timezone.utc) == datetime(
+        2025, 3, 30, 5, 0, tzinfo=timezone.utc
+    )
+
+
+def test_iso_with_z_suffix_still_handled():
+    # Z (UTC) timestamps are handled by the dedicated branch and converted.
+    result = TimestampParser().parse("2025-03-30T10:00:00Z", "Europe/Stockholm")
+    assert result.tzinfo is not None
+    assert result.astimezone(timezone.utc) == datetime(
+        2025, 3, 30, 10, 0, tzinfo=timezone.utc
+    )


### PR DESCRIPTION
## Bug
In [timezone/parser.py](custom_components/ge_spot/timezone/parser.py) the general-ISO offset check was:
```python
elif ("+" in timestamp_str or "-" in timestamp_str and "T" in timestamp_str):
```
`and` binds tighter than `or`, and the branch already runs under `if "T" in timestamp_str`, so this reduced to **`"+" in s or "-" in s`**. A **naive** ISO timestamp like `2025-03-30T10:00:00` contains `-` (date separators), so it wrongly took the "has timezone offset" path — `datetime.fromisoformat(...)` returns a **naive** datetime there, and `if dt.tzinfo and ...` is skipped, so it was returned **naive** instead of falling through to the branch that attaches the source timezone.

## Fix
Detect a real trailing offset suffix with `re.search(r"[+-]\d{2}:?\d{2}$", timestamp_str)`. Naive ISO now gets the source timezone attached (the intended `else`-branch behavior); `+offset` and `Z` timestamps are unchanged.

## Testing
- New [test_parser_iso_offset.py](tests/pytest/unit/test_parser_iso_offset.py): naive ISO is localized (**fails before the fix**), `+05:00` offset is preserved/converted, `Z` still handled.
- Full unit suite: **454 passed**. `black` clean.

Real logic bug (audit #8), low blast radius (the generic ISO fallback; most sources use Z or source-specific parsers).