### PR TITLE
Remove unused imports and an unreachable statement (pylint cleanup)

### DIFF
--- a/custom_components/ge_spot/api/parsers/nordpool_parser.py
+++ b/custom_components/ge_spot/api/parsers/nordpool_parser.py
@@ -1,7 +1,7 @@
 """Parser for Nordpool API responses."""
 
 import logging
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Dict, Any
 
 from ..base.price_parser import BasePriceParser

--- a/custom_components/ge_spot/coordinator/data_processor.py
+++ b/custom_components/ge_spot/coordinator/data_processor.py
@@ -2,7 +2,6 @@
 
 import logging
 import math
-import re
 from datetime import datetime, timedelta
 from typing import Any, Dict, Optional
 

--- a/custom_components/ge_spot/sensor/price.py
+++ b/custom_components/ge_spot/sensor/price.py
@@ -160,7 +160,6 @@ class ExtremaPriceSensor(PriceValueSensor):
                     return {"timestamp": formatted_time, "value": price_value}
                 except (ValueError, TypeError):
                     return {"timestamp": timestamp, "value": price_value}
-                return {"timestamp": timestamp, "value": price_value}
             return {}
 
         # Initialize parent class


### PR DESCRIPTION
Zero-risk cleanup that clears the two remaining pylint `unused-import` warnings (toward the 10/10 goal):
- [coordinator/data_processor.py](custom_components/ge_spot/coordinator/data_processor.py): drop unused `import re`.
- [api/parsers/nordpool_parser.py](custom_components/ge_spot/api/parsers/nordpool_parser.py): drop the unused `timezone` from `from datetime import datetime, timezone` (the file only uses `timezone` as a parameter / dict-key name, never `datetime.timezone`).
- [sensor/price.py](custom_components/ge_spot/sensor/price.py): remove an unreachable `return` after a `try/except` whose both branches already return (audit finding #31).

Pure cleanup, no behavior change. Full unit suite (**451**) passes; `black` clean.