### PR TITLE
Roll the price cache over at the displayed (target) timezone, not HA's

### DIFF
--- a/custom_components/ge_spot/coordinator/cache_manager.py
+++ b/custom_components/ge_spot/coordinator/cache_manager.py
@@ -65,9 +65,14 @@ class CacheManager:
             )
             return
 
-        # Use provided target_date if available, otherwise use timestamp's date
+        # Use provided target_date if available; otherwise derive it from the
+        # timestamp in the display (target) timezone so the cache files data
+        # under the same day the prices are split/displayed in (see
+        # _to_target_tz). For same-timezone setups this equals timestamp.date().
         actual_target_date = (
-            target_date if target_date is not None else timestamp.date()
+            target_date
+            if target_date is not None
+            else self._to_target_tz(timestamp).date()
         )
 
         cache_key = self._generate_cache_key(area, source, actual_target_date)
@@ -96,6 +101,26 @@ class CacheManager:
         """Generate a consistent cache key including the target date."""
         date_str = target_date.isoformat()  # Format date as YYYY-MM-DD
         return f"{area}_{date_str}_{source}"
+
+    def _to_target_tz(self, value: datetime) -> datetime:
+        """Convert a timezone-aware datetime to the display (target) timezone.
+
+        Prices are split into today/tomorrow and keyed by interval in the target
+        timezone (the area timezone in LOCAL_AREA mode, the HA timezone
+        otherwise). The cache must therefore file days and detect the midnight
+        rollover in that same timezone; otherwise, for a user whose HA system
+        timezone differs from the area/display timezone, the day would roll over
+        at HA-system midnight instead of the displayed midnight. Returns the
+        value unchanged if no timezone service/target is available (e.g. before
+        it is wired up, or in tests).
+        """
+        target_tz = getattr(self._timezone_service, "target_timezone", None)
+        if target_tz is None:
+            return value
+        try:
+            return value.astimezone(target_tz)
+        except (TypeError, ValueError, AttributeError):
+            return value
 
     def get_data(
         self,
@@ -225,12 +250,15 @@ class CacheManager:
         # If no valid entries were found for today's date, check if we have yesterday's data with tomorrow's prices
         # This handles the midnight transition case
         now = dt_util.now()
-        current_date = now.date()
+        # Detect the rollover in the display (target) timezone, not the HA-system
+        # timezone, so promotion fires at the displayed midnight (see _to_target_tz).
+        rollover_now = self._to_target_tz(now)
+        current_date = rollover_now.date()
 
         # Only attempt the migration if we're looking for today's date and it's just after midnight
         if target_date == current_date:
             # Only allow migration between 00:00 and 00:10 (10 minute window after midnight)
-            if now.hour == 0 and now.minute < 10:
+            if rollover_now.hour == 0 and rollover_now.minute < 10:
                 yesterday = target_date - timedelta(days=1)
                 _LOGGER.debug(
                     "No valid cache entries for today (%s). Checking yesterday's cache for tomorrow's data.",

--- a/custom_components/ge_spot/coordinator/unified_price_manager.py
+++ b/custom_components/ge_spot/coordinator/unified_price_manager.py
@@ -546,6 +546,25 @@ class UnifiedPriceManager:
             # fail safe to serving the cache rather than forcing a refetch.
             return False
 
+    def _today_in_target_tz(self, now: datetime) -> date:
+        """Return "today" as a date in the display (target) timezone.
+
+        Prices are split into today/tomorrow and keyed by interval in the target
+        timezone (the area timezone in LOCAL_AREA mode, the HA timezone
+        otherwise). Anchoring the cache lookup and the midnight rollover to that
+        same timezone keeps them consistent for a user whose HA system timezone
+        differs from the area/display timezone; without it the day would roll
+        over at HA-system midnight rather than the displayed midnight. Falls back
+        to the HA-local date if the target timezone is unavailable (e.g. tests).
+        """
+        target_tz = getattr(self._tz_service, "target_timezone", None)
+        if target_tz is None:
+            return now.date()
+        try:
+            return now.astimezone(target_tz).date()
+        except (TypeError, ValueError, AttributeError):
+            return now.date()
+
     async def fetch_data(self, force: bool = False) -> Dict[str, Any]:
         """Fetch price data with implicit source validation.
 
@@ -560,7 +579,7 @@ class UnifiedPriceManager:
             Dictionary with processed data
         """
         now = dt_util.now()
-        today_date = now.date()  # Get today's date
+        today_date = self._today_in_target_tz(now)  # "Today" in the display tz
         area_key = self.area  # Key for rate limiting
 
         # Ensure exchange service is initialized before fetching/processing

--- a/tests/pytest/unit/test_midnight_migration.py
+++ b/tests/pytest/unit/test_midnight_migration.py
@@ -347,5 +347,108 @@ class TestMigrationIntegration:
         # and trigger a fetch after 13:00 when tomorrow prices are published
 
 
+class TestCrossTimezoneMidnight:
+    """Day rollover must follow the DISPLAY (target) timezone, not the HA system tz.
+
+    Regression for the global midnight bug: a user whose HA system timezone
+    differs from the area/display timezone must see the day roll over (and the
+    pre-fetched tomorrow promoted to today) at the *displayed* midnight, not at
+    HA-system midnight. Scenario: HA in America/New_York viewing a Europe/
+    Stockholm area (6 h ahead in winter), at an instant just past Stockholm
+    midnight but still the previous calendar day in New York.
+    """
+
+    def _cache_manager(self, hass, target_tz):
+        tz_service = Mock()
+        tz_service.target_timezone = target_tz
+        tz_service.get_current_interval_key.return_value = "00:00"
+        mgr = CacheManager(hass=hass, config={"cache_ttl": 60})
+        mgr._timezone_service = tz_service
+        return mgr
+
+    def test_promotion_follows_display_midnight_not_ha_midnight(
+        self, mock_hass, yesterday_cache_data
+    ):
+        ha_tz = ZoneInfo("America/New_York")
+        target_tz = ZoneInfo("Europe/Stockholm")
+        mgr = self._cache_manager(mock_hass, target_tz)
+
+        # 18:05 New York (Jan 15) == 00:05 Stockholm (Jan 16): a new display day,
+        # still the previous day on the HA-system clock.
+        ha_now = datetime(2026, 1, 15, 18, 5, 0, tzinfo=ha_tz)
+        display_today = date(2026, 1, 16)
+        display_yesterday = date(2026, 1, 15)
+
+        # Yesterday's (display) cache holds tomorrow's prices (== display today).
+        mgr.store(
+            area="SE2",
+            source="nordpool",
+            data=yesterday_cache_data,
+            timestamp=ha_now,
+            target_date=display_yesterday,
+        )
+
+        with patch(
+            "custom_components.ge_spot.coordinator.cache_manager.dt_util"
+        ) as mock_dt:
+            mock_dt.now.return_value = ha_now
+            migrated = mgr.get_data(area="SE2", target_date=display_today)
+
+        # On the old (HA-tz) logic this returns None: current_date would be Jan 15
+        # (!= target Jan 16) and now.hour would be 18 (outside the 00:00-00:10
+        # window), so promotion never fires and "today" is empty.
+        assert (
+            migrated is not None
+        ), "Promotion must fire at displayed midnight even though the HA clock reads 18:05"
+        assert migrated.migrated_from_tomorrow is True
+        assert len(migrated.today_interval_prices) == 96
+        assert len(migrated.tomorrow_interval_prices) == 0
+
+    def test_store_files_under_display_day(self, mock_hass, yesterday_cache_data):
+        ha_tz = ZoneInfo("America/New_York")
+        target_tz = ZoneInfo("Europe/Stockholm")
+        mgr = self._cache_manager(mock_hass, target_tz)
+
+        # Same instant; store WITHOUT an explicit target_date must file under the
+        # display day (Jan 16, Stockholm), not the HA-system day (Jan 15, NY).
+        ha_now = datetime(2026, 1, 15, 18, 5, 0, tzinfo=ha_tz)
+
+        mgr.store(
+            area="SE2",
+            source="nordpool",
+            data=yesterday_cache_data,
+            timestamp=ha_now,
+        )
+
+        entries = mgr.get_cache_stats().get("entries", {})
+        filed_dates = {
+            info.get("metadata", {}).get("target_date") for info in entries.values()
+        }
+        assert (
+            "2026-01-16" in filed_dates
+        ), f"Data must be filed under the display-tz day, got {filed_dates}"
+        assert (
+            "2026-01-15" not in filed_dates
+        ), f"Data must NOT be filed under the HA-system-tz day, got {filed_dates}"
+
+    def test_same_timezone_is_unchanged(self, mock_hass, yesterday_cache_data):
+        """When HA tz == display tz, behaviour is identical to before (no-op)."""
+        tz = ZoneInfo("Europe/Stockholm")
+        mgr = self._cache_manager(mock_hass, tz)
+
+        now_local = datetime(2026, 1, 16, 0, 5, 0, tzinfo=tz)
+        mgr.store(
+            area="SE2",
+            source="nordpool",
+            data=yesterday_cache_data,
+            timestamp=now_local,
+        )
+        entries = mgr.get_cache_stats().get("entries", {})
+        filed_dates = {
+            info.get("metadata", {}).get("target_date") for info in entries.values()
+        }
+        assert filed_dates == {"2026-01-16"}
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problem
The today/tomorrow split and all interval keys are computed in the **target timezone** (area tz in `LOCAL_AREA` mode, HA tz otherwise), but the cache filed entries, looked them up, and detected the midnight rollover using `dt_util.now()` in **HA's system timezone**. When a user's HA system timezone differs from the area/display timezone, the day rolls over at HA-system midnight instead of the displayed midnight — so around the boundary the cache lookup and the midnight promotion disagree with the split by a full day.

## Fix
Anchor the whole cache lifecycle to the display (target) timezone:
- `CacheManager._to_target_tz()` converts a timestamp to the target tz (falls back to unchanged if no tz service).
- `store()` files entries under the **target-tz date** when no explicit `target_date` is given (was `timestamp.date()` in HA tz).
- the midnight-migration check detects the rollover in the target tz — **the 00:00–00:10 rate-limit window is kept**.
- `UnifiedPriceManager` computes `today_date` for cache lookups in the target tz.

## Safety
- **No-op for same-timezone setups** (the common case): target tz == HA tz, so every date is unchanged.
- Adds cross-timezone regression tests (HA in `America/New_York` viewing a `Europe/Stockholm` area) that **fail without** this change and pass with it.
- Full unit suite green; black clean; pylint unchanged.

## Empirical evidence
A 10-timezone simulation against **real Nord Pool SE4 data** (UTC, Stockholm, London, NY, LA, Kolkata +5:30, Kathmandu +5:45, Adelaide +9:30, Chatham +12:45, Tokyo) confirms the same absolute instant returns the identical, correct price in every zone — the timezone only changes the HH:MM label, never the value.

## Not included (deliberate)
- The day-ahead **publish-time** threshold (`PUBLICATION_TIMES_UTC`) is a deliberate conservative buffer, not a bug — left as-is.
- The **fetch-coverage** layer (a cold-start cross-tz fetch may not cover the target's today until the next publish/UTC-midnight) is a separate, larger change and is **not** addressed here.