### PR TITLE
Stop requesting the invalid A65 document type from ENTSO-E

### DIFF
--- a/custom_components/ge_spot/api/entsoe.py
+++ b/custom_components/ge_spot/api/entsoe.py
@@ -215,8 +215,10 @@ class EntsoeAPI(BasePriceAPI):
             period_start = start_date.strftime(TimeFormat.ENTSOE_DATE_HOUR)
             period_end = end_date.strftime(TimeFormat.ENTSOE_DATE_HOUR)
 
-            # Try different document types (A44: day-ahead prices, A65: week-ahead prices)
-            doc_types = ["A44", "A65"]
+            # A44 is the day-ahead price document. (A65 is a system-load document,
+            # not a price document; ENTSO-E rejects it for these domains with
+            # HTTP 400 "DOCUMENT_TYPE=A65 is not valid", so it is never requested.)
+            doc_types = ["A44"]
 
             for doc_type in doc_types:
                 params = {


### PR DESCRIPTION
## Problem
The day-ahead price fetch tried `documentType` **A44** then **A65** (`doc_types = ["A44", "A65"]`). A65 is a **system-load** document, not a price document — ENTSO-E rejects it for these domains with **HTTP 400**: *"The combination of [DOCUMENT_TYPE=A65] is not valid, or the requested data is not allowed."* Verified live against IT, IT-South-2, and UA-IPS (all 400 on A65; all 200 on A44).

So the A65 fallback could never return prices; it only emitted a 400 error whenever A44 didn't fully satisfy (e.g. during a transient A44 hiccup), and was a latent load-as-price hazard if it ever did parse.

## Fix
Request **A44 only**. One-line change + comment.

## Verified live
After deploying, the recurring `API request failed with status 400` / `DOCUMENT_TYPE=A65` errors dropped to **0**.