### PR TITLE
Expand hourly Energy-Charts zones onto the 15-minute grid

### DIFF
--- a/custom_components/ge_spot/api/parsers/energy_charts_parser.py
+++ b/custom_components/ge_spot/api/parsers/energy_charts_parser.py
@@ -5,9 +5,11 @@ from datetime import datetime, timezone
 from typing import Dict, Any
 
 from ..base.price_parser import BasePriceParser
+from ..interval_expander import convert_to_target_intervals
 from ...const.sources import Source
 from ...const.currencies import Currency
 from ...const.energy import EnergyUnit
+from ...const.time import TimeInterval
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -154,6 +156,33 @@ class EnergyChartsParser(BasePriceParser):
             f"[EnergyChartsParser] Parsed {len(interval_raw)} prices. "
             f"Sample keys: {list(interval_raw.keys())[:3]}"
         )
+
+        # Energy-Charts returns hourly data for some zones (e.g. CH) and 15-min for
+        # others (e.g. SE4). Expand a coarser-than-target resolution onto the
+        # integration's interval grid so an hourly zone yields a full 96-interval
+        # day instead of 24/96 (which would leave no current-interval price when
+        # this source is used). The source step is detected from the spacing of the
+        # API timestamps; a 15-min source is a no-op.
+        # Detect the step from the first two PARSED interval keys (valid ISO
+        # timestamps) rather than the raw input, so invalid/missing entries can't
+        # break the detection.
+        if len(interval_raw) >= 2:
+            ordered_keys = sorted(interval_raw)
+            step_minutes = int(
+                (
+                    datetime.fromisoformat(ordered_keys[1])
+                    - datetime.fromisoformat(ordered_keys[0])
+                ).total_seconds()
+                // 60
+            )
+            if step_minutes and step_minutes != TimeInterval.get_interval_minutes():
+                interval_raw = convert_to_target_intervals(
+                    interval_raw, source_interval_minutes=step_minutes
+                )
+                _LOGGER.debug(
+                    f"[EnergyChartsParser] Expanded {step_minutes}-min source to "
+                    f"{len(interval_raw)} target intervals"
+                )
 
         # Construct result
         result = {

--- a/tests/pytest/unit/test_energy_charts_parser.py
+++ b/tests/pytest/unit/test_energy_charts_parser.py
@@ -65,6 +65,47 @@ class TestEnergyChartsParser:
             "license_info": sample_energy_charts_data["license_info"],
         }
 
+    @pytest.fixture
+    def sample_hourly_data(self):
+        """Energy-Charts response for an HOURLY zone (e.g. CH): 24 points/day."""
+        start = datetime(2025, 10, 7, 0, 0, 0, tzinfo=timezone.utc).timestamp()
+        unix_seconds = [int(start + i * 3600) for i in range(24)]  # 1-hour steps
+        prices = [round(50.0 + i, 2) for i in range(24)]
+        return {
+            "unix_seconds": unix_seconds,
+            "price": prices,
+            "unit": "EUR / MWh",
+            "license_info": "x",
+        }
+
+    def test_hourly_zone_expands_to_full_15min_day(self, parser, sample_hourly_data):
+        """An hourly zone (24 points) must expand to a full 96-interval day.
+
+        Otherwise hourly Energy-Charts zones (e.g. CH) parse as 24/96 and have no
+        price for the current 15-min interval (has_current=False).
+        """
+        raw = {
+            "raw_data": sample_hourly_data,
+            "timezone": "Europe/Berlin",
+            "currency": Currency.EUR,
+            "area": "CH",
+            "license_info": "x",
+        }
+        prices = parser.parse(raw)["interval_raw"]
+        assert (
+            len(prices) == 96
+        ), f"hourly 24 points should expand to 96, got {len(prices)}"
+        # The hourly price is held constant across its four 15-min sub-slots.
+        assert prices["2025-10-07T00:00:00+00:00"] == 50.0
+        assert prices["2025-10-07T00:15:00+00:00"] == 50.0
+        assert prices["2025-10-07T00:45:00+00:00"] == 50.0
+        assert prices["2025-10-07T01:00:00+00:00"] == 51.0
+
+    def test_native_15min_zone_is_unchanged(self, parser, full_input_data):
+        """A 15-min zone (96 points) is a no-op for the expansion (still 96)."""
+        prices = parser.parse(full_input_data)["interval_raw"]
+        assert len(prices) == 96
+
     def test_parse_de_lu_data(self, parser, full_input_data):
         """Test parsing DE-LU (Germany-Luxembourg) data."""
         result = parser.parse(full_input_data)

--- a/tests/pytest/unit/test_parser_raw_data_parameter.py
+++ b/tests/pytest/unit/test_parser_raw_data_parameter.py
@@ -513,7 +513,9 @@ class TestAPIResponseFormats:
         result = parser.parse(test_data)
 
         assert "interval_raw" in result
-        assert len(result["interval_raw"]) == 3
+        # The 3 points are hourly (3600s apart); Energy-Charts hourly data is
+        # expanded onto the 15-min grid, so 3 hours -> 3 x 4 = 12 intervals.
+        assert len(result["interval_raw"]) == 12
 
     def test_omie_csv_text_input(self, timezone_service):
         """Test OMIE parser handles CSV text input."""


### PR DESCRIPTION
## Problem
Energy-Charts returns **hourly** data for some zones (e.g. **CH**) and 15-min for others (e.g. SE4), but the parser kept whatever resolution the API returned. An hourly zone therefore parsed as **24/96** intervals → **no price for the current 15-min interval** (`has_current=False`).

Found live: during an ENTSO-E upstream outage, CH (entsoe primary) fell back to Energy-Charts and showed `today=24, has_current=False`. Verified: `api.energy-charts.info/price?bzn=CH` returns 24 points at 60-min spacing, and the Energy-Charts parser — unlike `omie_parser`/`aemo_parser`/`comed_parser` — does **not** call `convert_to_target_intervals`.

## Fix
Detect the source step from the first two parsed interval keys and expand a coarser-than-target resolution onto the 15-min grid via the existing `interval_expander` (same pattern the OMIE/AEMO/ComEd parsers already use). A 15-min source is a **no-op**. Step detection reads the parsed ISO keys, not the raw input, so invalid/missing timestamps can't break it.

## Tests
- New: hourly (24 points) → 96; native 15-min (96) unchanged.
- Updated one existing test (`test_energy_charts_unix_timestamp_input`): its 3 **hourly** points now expand to **12** (3 × 4) — reflecting the intended expansion, not masking a regression.
- Full suite **495 pass / 3 skip**; black clean; pylint 9.70.

## Scope / reviewer note
This changes Energy-Charts parsing for **all** hourly zones (no-op for 15-min zones, which are the common case). Not deployed here yet — flagged for review since Energy-Charts is a common primary/fallback source.